### PR TITLE
Strips mysterious whitespace from URI

### DIFF
--- a/project_electron/transfer_app/lib/bag_checker.py
+++ b/project_electron/transfer_app/lib/bag_checker.py
@@ -53,12 +53,12 @@ class bagChecker():
             print 'No BagIt Profile to validate against'
             return False
         else:
-            if BI_fields['BagIt_Profile_Identifier'] != 'https://raw.githubusercontent.com/RockefellerArchiveCenter/project_electron/master/transfer/organizational-bag-profile.json':
+            if BI_fields['BagIt_Profile_Identifier'].strip() != 'https://raw.githubusercontent.com/RockefellerArchiveCenter/project_electron/master/transfer/organizational-bag-profile.json':
                 print "Bag Identifier is not RAC version"
                 return False
 
             # self.bag = bagit.Bag(self.archive_path)
-            profile = bagit_profile.Profile(BI_fields['BagIt_Profile_Identifier'])
+            profile = bagit_profile.Profile(BI_fields['BagIt_Profile_Identifier'].strip())
 
             if profile.validate(self.bag):
                 print "Bag valid according to RAC profile"


### PR DESCRIPTION
In some bag-info.txt files, extraneous whitespace was causing validation to fail. Uses `strip()` to remove surrounding whitespace.