### PR TITLE
Improve validation of metadata file

### DIFF
--- a/project_electron/transfer_app/lib/bag_checker.py
+++ b/project_electron/transfer_app/lib/bag_checker.py
@@ -118,8 +118,7 @@ class bagChecker():
                 return json.loads(FH.get_file_contents(metadata_file))
             except ValueError as e:
                 print "invalid json: {}".format(e)
-
-        return False
+                return False
 
     def bag_passed_all(self):
         if not self.archive_extracted:

--- a/project_electron/transfer_app/lib/bag_checker.py
+++ b/project_electron/transfer_app/lib/bag_checker.py
@@ -112,6 +112,7 @@ class bagChecker():
 
         if not isfile(metadata_file):
             print 'no metadata file'
+            return True
         else:
             try:
                 return json.loads(FH.get_file_contents(metadata_file))


### PR DESCRIPTION
When no `metadata.json` file is present in the `data/` directory, the validation function should return true, since this file is optional. 