### PR TITLE
moves forms to form file, cleans up duplicate views

### DIFF
--- a/project_electron/orgs/form.py
+++ b/project_electron/orgs/form.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.contrib.auth.forms import PasswordChangeForm
+
 from orgs.models import User
 
 class OrgUserUpdateForm(forms.ModelForm):
@@ -16,3 +18,22 @@ class RACSuperUserUpdateForm(forms.ModelForm):
 		model = User
 		# NO ORG -- SET TO PRIMARY
 		fields = ['is_active','email','is_superuser']
+
+class UserPasswordChangeForm(PasswordChangeForm):
+    error_css_class = 'has-error'
+    error_messages = {'password_incorrect': "You entered your current password incorrectly"}
+    old_password = forms.CharField(required=True, label='Current Password',
+                  widget=forms.PasswordInput(attrs={
+                    'class': 'form-control'}),
+                  error_messages={
+                    'required': 'Please enter your current password'})
+    new_password1 = forms.CharField(required=True, label='New Password',
+                  widget=forms.PasswordInput(attrs={
+                    'class': 'form-control'}),
+                  error_messages={
+                    'required': 'Please enter your new password'})
+    new_password2 = forms.CharField(required=True, label='New Password (repeat)',
+                  widget=forms.PasswordInput(attrs={
+                    'class': 'form-control'}),
+                  error_messages={
+                    'required': 'Please confirm your new password'})

--- a/project_electron/orgs/views.py
+++ b/project_electron/orgs/views.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from django.views.generic import ListView, UpdateView, CreateView, DetailView, View
 from django.contrib.auth.views import PasswordChangeView
-from django.contrib.auth.forms import PasswordChangeForm
 
 from orgs.models import Organization, User
 from django.utils import timezone
@@ -13,7 +12,7 @@ from django.http import JsonResponse
 from django.contrib.messages.views import SuccessMessageMixin
 
 from orgs.models import Archives
-from orgs.form import OrgUserUpdateForm, RACSuperUserUpdateForm
+from orgs.form import OrgUserUpdateForm, RACSuperUserUpdateForm, UserPasswordChangeForm
 
 from django import forms
 from django.contrib import messages
@@ -165,70 +164,6 @@ class UsersTransfersView(RACUserMixin, ListView):
     def get_queryset(self):
         self.user = get_object_or_404(User, pk=self.kwargs['pk'])
         return Archives.objects.filter(user_uploaded=self.user).order_by('-created_time')
-
-class UserPasswordChangeForm(PasswordChangeForm):
-    error_css_class = 'has-error'
-    error_messages = {'password_incorrect': "You entered your current password incorrectly"}
-    old_password = forms.CharField(required=True, label='Current Password',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please enter your current password'})
-    new_password1 = forms.CharField(required=True, label='New Password',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please enter your new password'})
-    new_password2 = forms.CharField(required=True, label='New Password (repeat)',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please confirm your new password'})
-
-class UserPasswordChangeView(PasswordChangeView, SuccessMessageMixin):
-    template_name = 'orgs/users/password_change.html'
-    model = User
-    success_message = "New password saved."
-    form_class = UserPasswordChangeForm
-
-    def get_context_data(self,**kwargs):
-        context = super(UserPasswordChangeView, self).get_context_data(**kwargs)
-        context['meta_page_title'] = 'Change Password'
-        return context
-
-    def get_success_url(self):
-        return reverse('users-detail', kwargs={'pk': self.object.pk})
-
-class UsersTransfersView(RACUserMixin, ListView):
-    template_name = 'orgs/all_transfers.html'
-    def get_context_data(self,**kwargs):
-        context = super(UsersTransfersView, self).get_context_data(**kwargs)
-        context['user'] = self.user
-        context['meta_page_title'] = 'My Transfers'
-        return context
-
-    def get_queryset(self):
-        self.user = get_object_or_404(User, pk=self.kwargs['pk'])
-        return Archives.objects.filter(user_uploaded=self.user).order_by('-created_time')
-
-class UserPasswordChangeForm(PasswordChangeForm):
-    error_css_class = 'has-error'
-    error_messages = {'password_incorrect': "You entered your current password incorrectly"}
-    old_password = forms.CharField(required=True, label='Current Password',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please enter your current password'})
-    new_password1 = forms.CharField(required=True, label='New Password',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please enter your new password'})
-    new_password2 = forms.CharField(required=True, label='New Password (repeat)',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please confirm your new password'})
 
 class UserPasswordChangeView(PasswordChangeView, SuccessMessageMixin):
     template_name = 'orgs/users/password_change.html'

--- a/project_electron/rac_user/form.py
+++ b/project_electron/rac_user/form.py
@@ -1,0 +1,23 @@
+from django import forms
+from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
+
+from orgs.models import User
+
+class UserPasswordResetForm(PasswordResetForm):
+    email = forms.EmailField(required=True,
+                  widget=forms.EmailInput(attrs={
+                    'class': 'form-control has-feedback'}),
+                  error_messages={
+                    'required': 'Please enter your email'})
+
+class UserPasswordResetConfirmForm(SetPasswordForm):
+    new_password1 = forms.CharField(required=True, label='New Password',
+                  widget=forms.PasswordInput(attrs={
+                    'class': 'form-control'}),
+                  error_messages={
+                    'required': 'Please enter your new password'})
+    new_password2 = forms.CharField(required=True, label='New Password (repeat)',
+                  widget=forms.PasswordInput(attrs={
+                    'class': 'form-control'}),
+                  error_messages={
+                    'required': 'Please confirm your new password'})

--- a/project_electron/rac_user/views.py
+++ b/project_electron/rac_user/views.py
@@ -2,11 +2,12 @@
 from __future__ import unicode_literals
 from django.views.generic import TemplateView
 from django.contrib.auth.views import PasswordResetView, PasswordResetDoneView, PasswordResetConfirmView, PasswordResetCompleteView
-from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
 from django.core.urlresolvers import reverse_lazy
 from django import forms
 
 from django.shortcuts import render, redirect
+
+from rac_user.form import UserPasswordResetForm, UserPasswordResetConfirmForm
 
 from braces.views import AnonymousRequiredMixin
 
@@ -16,13 +17,6 @@ class SplashView(AnonymousRequiredMixin, TemplateView):
 
     def get(self, request):
         return redirect('login')
-
-class UserPasswordResetForm(PasswordResetForm):
-    email = forms.EmailField(required=True,
-                  widget=forms.EmailInput(attrs={
-                    'class': 'form-control has-feedback'}),
-                  error_messages={
-                    'required': 'Please enter your email'})
 
 class UserPasswordResetView(AnonymousRequiredMixin, PasswordResetView):
     template_name = 'rac_user/password_reset.html'
@@ -40,18 +34,6 @@ class UserPasswordResetDoneView(AnonymousRequiredMixin, PasswordResetDoneView):
         context = super(PasswordResetDoneView, self).get_context_data(**kwargs)
         context['meta_page_title'] = 'Password Reset Link Sent'
         return context
-
-class UserPasswordResetConfirmForm(SetPasswordForm):
-    new_password1 = forms.CharField(required=True, label='New Password',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please enter your new password'})
-    new_password2 = forms.CharField(required=True, label='New Password (repeat)',
-                  widget=forms.PasswordInput(attrs={
-                    'class': 'form-control'}),
-                  error_messages={
-                    'required': 'Please confirm your new password'})
 
 class UserPasswordResetConfirmView(AnonymousRequiredMixin, PasswordResetConfirmView):
     template_name = 'rac_user/password_reset_confirm.html'


### PR DESCRIPTION
This cleans up some of the mess I made earlier - moves forms to a `form.py` file, where they belong. Also removes two duplicate (`UserPasswordChangeView` and `UsersTransfersView`) views in `orgs` which were inadvertently created in merge.