### PR TITLE
Adds UI for updating groups

### DIFF
--- a/project_electron/orgs/form.py
+++ b/project_electron/orgs/form.py
@@ -10,7 +10,7 @@ from orgs.models import User
 class OrgUserUpdateForm(forms.ModelForm):
 	class Meta:
 		model = User
-		fields = ['is_active','email','organization','is_org_admin']
+		fields = ['is_active','email','organization','groups']
 
 # class RACUserUpdateForm(forms.ModelForm):
 # 	class Meta:
@@ -21,7 +21,7 @@ class RACSuperUserUpdateForm(forms.ModelForm):
 	class Meta:
 		model = User
 		# NO ORG -- SET TO PRIMARY
-		fields = ['is_active','email','is_superuser']
+		fields = ['is_active','email','groups']
 
 
 class UserPasswordChangeForm(PasswordChangeForm):

--- a/project_electron/orgs/templates/orgs/users/update.html
+++ b/project_electron/orgs/templates/orgs/users/update.html
@@ -1,4 +1,5 @@
 {% extends 'transfer_app/base.html' %}
+{% load util %}
 
 {% block h1_title %}{{page_title}}{% endblock %}
 
@@ -21,7 +22,7 @@
                         </div>
                     {% endif %}
 
-                    {% if request.user.in_group.managing_archivists or request.user.is_superuser %}
+                    {% if request.user.is_manager or request.user.is_superuser %}
                     <div class="checkbox">
                       <label>
                         <input type="checkbox" name="is_active" {% if object.is_active %}checked{% endif %}> Active?
@@ -47,16 +48,16 @@
                         </div>
                         {% endif %}
 
-                        <div class="checkbox">
-                          <label>
-                            <input type="checkbox" name="is_superuser" {% if object.is_superuser %}checked{% endif %}> RAC Admin?
-                          </label>
-                        </div>
-                    {% else %}
-                        <div class="checkbox">
-                          <label>
-                            <input type="checkbox" name="is_org_admin" {% if object.is_org_admin %}checked{% endif %}> Org Admin?
-                          </label>
+                        <div class="form-group">
+                            <label>Groups</label>
+                            {% for group in form.fields.groups.choices %}
+                            <div class="checkbox">
+                              <label>
+                                <input name="groups" type="checkbox" value="{{group.0}}" {% if object|has_group:group.1 %}checked="checked"{% endif %}>
+                                {{group.1}}
+                              </label>
+                            </div>
+                            {% endfor %}
                         </div>
 
                     {% endif %}

--- a/project_electron/transfer_app/templatetags/util.py
+++ b/project_electron/transfer_app/templatetags/util.py
@@ -1,7 +1,12 @@
 from django import template
+from django.contrib.auth.models import Group
 
 register = template.Library()
 
 @register.filter
 def get_type(value):
     return type(value).__name__
+
+@register.filter
+def has_group(user, group_name):
+    return user.groups.filter(name=group_name).exists()


### PR DESCRIPTION
Changes user update page so authorized users can edit the groups a user is assigned to. fixes #181 

This also removes `is_superuser` and `org_admin` from forms and templates, since those are not meaningfully used right now.

**To deploy add the following groups via Django admin**
`appraisal_archivists`
`accessioning_archivists`
`managing_archivists`
`system_administrators`