### PR TITLE
update footer with correct license info

### DIFF
--- a/project_electron/transfer_app/templates/transfer_app/footer.html
+++ b/project_electron/transfer_app/templates/transfer_app/footer.html
@@ -1,9 +1,8 @@
 {% load static %}
 <footer class="main-footer">
-  <!-- Default to the left -->
-  <!-- Logo -->
   <a href="http://rockarch.org/" class="logo-lg">
   	<img src="{% static "dist/img/RAC-logo.png" %}" alt="The Rockefeller Archive Center">
   </a>
-  <strong>Copyright 2017 &copy; <a href="http://rockarch.org/">Rockefeller Archive Center.</a></strong> All rights reserved.
+  <strong><a href="https://github.com/RockefellerArchiveCenter/aurora/blob/master/LICENSE">MIT License</a>
+    &copy; 2017 Rockefeller Archive Center.</strong>
 </footer>

--- a/project_electron/transfer_app/templates/transfer_app/footer.html
+++ b/project_electron/transfer_app/templates/transfer_app/footer.html
@@ -3,6 +3,6 @@
   <a href="http://rockarch.org/" class="logo-lg">
   	<img src="{% static "dist/img/RAC-logo.png" %}" alt="The Rockefeller Archive Center">
   </a>
-  <strong><a href="https://github.com/RockefellerArchiveCenter/aurora/blob/master/LICENSE">MIT License</a>
-    &copy; 2017 Rockefeller Archive Center.</strong>
+  &copy; 2017 Rockefeller Archive Center. Aurora code available under the
+  <a href="https://github.com/RockefellerArchiveCenter/aurora/blob/master/LICENSE">MIT License.</a>
 </footer>


### PR DESCRIPTION
Removes "all rights reserved" language and adds link to MIT license. Fixes #206