### PR TITLE
Removes hardcoded path from wsgi.py

### DIFF
--- a/aurora/aurora/wsgi.py
+++ b/aurora/aurora/wsgi.py
@@ -8,14 +8,8 @@ https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os
-import sys
 
 from django.core.wsgi import get_wsgi_application
-
-path = '/data/htdocs/aurora/aurora'
-
-if path not in sys.path:
-    sys.path.append(path)
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "aurora.settings")
 


### PR DESCRIPTION
tl;dr: After properly configuring Apache, hardcoded paths are no longer necessary. 

slightly longer version: the Apache config files were incorrectly formed, with some variables set outside of the `VirtualHost` block. Additionally, settings for `wsgi.py` may have been incomplete. The correct version of the config files has been added to deployment documentation.

fixes #410