### PR TITLE
Improves test performance

### DIFF
--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -330,7 +330,7 @@ def create_rights_granted(rights_statement=None, granted_count=1):
 def create_test_archives(organization=None, process_status=None, count=1):
     archives = []
     organization = organization if organization else random.choice(Organization.objects.all())
-    process_status = process_status if process_status else random.choice(Archives.processing_statuses)
+    process_status = process_status if process_status else random.choice(Archives.processing_statuses)[0]
     try:
         user = random.choice(User.objects.filter(organization=organization))
     except IndexError:

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -9,11 +9,10 @@ from bag_transfer.lib import files_helper as FH
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
                                  Archives, BagItProfile, BagItProfileBagInfo,
-                                 BagItProfileBagInfoValues, BAGLogCodes,
-                                 LanguageCode, ManifestsAllowed,
-                                 ManifestsRequired, Organization,
-                                 RecordCreators, TagFilesRequired,
-                                 TagManifestsRequired, User)
+                                 BagItProfileBagInfoValues, LanguageCode,
+                                 ManifestsAllowed, ManifestsRequired,
+                                 Organization, RecordCreators,
+                                 TagFilesRequired, TagManifestsRequired, User)
 from bag_transfer.rights.models import (RecordType, RightsStatement,
                                         RightsStatementCopyright,
                                         RightsStatementLicense,
@@ -133,28 +132,6 @@ def create_test_orgs(org_count=1):
 def delete_test_orgs(orgs=[]):
     for org in orgs:
         org.delete()
-
-
-def create_test_baglogcodes():
-    baglogcodes = (
-        ("ASAVE", "I"),
-        ("PBAG", "S"),
-        ("PBAGP", "S"),
-        ("GBERR", "BE"),
-        ("DTERR", "BE"),
-        ("MDERR", "BE"),
-        ("RBERR", "BE"),
-        ("BIERR", "BE"),
-    )
-    code_objects = []
-    for code in baglogcodes:
-        if not BAGLogCodes.objects.filter(code_short=code[0]).exists():
-            bag_log_code = BAGLogCodes(
-                code_short=code[0], code_type=code[1], code_desc=random_string(50),
-            )
-            bag_log_code.save()
-            code_objects.append(bag_log_code)
-    return code_objects
 
 
 def create_test_user(username=None, password=None, org=None, groups=[], is_staff=False):

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -47,7 +47,7 @@ def random_date(year):
 
 def random_name(prefix, suffix):
     """Returns a random name."""
-    return "{} {} {}".format(prefix, random.choice(string.ascii_letters), suffix)
+    return "{} {} {}".format(prefix, random_string(5), suffix)
 
 
 ####################################
@@ -69,7 +69,6 @@ def create_test_record_types(record_types=None):
     for record_type in record_types:
         object = RecordType.objects.create(name=record_type)
         objects.append(object)
-        print("Test record type {record_type} created".format(record_type=object.name))
     return objects
 
 
@@ -88,9 +87,7 @@ def create_test_groups(names=None):
             group = Group(name=name)
             group.save()
             groups.append(group)
-            print("Test group {group} created".format(group=group.name))
         else:
-            print("Test group {group} already exists".format(group=name))
             group = Group.objects.get(name=name)
             groups.append(group)
     return groups
@@ -107,8 +104,7 @@ def create_test_orgs(org_count=1):
             break
         new_org_name = random_name(
             random.choice(org_setup.POTUS_NAMES),
-            random.choice(org_setup.COMPANY_SUFFIX),
-        )
+            random.choice(org_setup.COMPANY_SUFFIX))
         try:
             Organization.objects.get(name=new_org_name)
             continue
@@ -116,16 +112,9 @@ def create_test_orgs(org_count=1):
             pass
 
         test_org = Organization(
-            name=new_org_name, machine_name="org{}".format((len(generated_orgs) + 1))
-        )
+            name=new_org_name, machine_name="org{}".format((len(generated_orgs) + 1)))
         test_org.save()
         generated_orgs.append(test_org)
-
-        print(
-            "Test organization {} -- {} created".format(
-                test_org.name, test_org.machine_name
-            )
-        )
 
     return generated_orgs
 
@@ -155,13 +144,12 @@ def create_test_user(username=None, password=None, org=None, groups=[], is_staff
     if password:
         test_user.set_password(password)
     test_user.save()
-    print("Test user {username} created".format(username=username))
     return test_user
 
 
 def create_target_bags(target_str, test_bags_dir, org, username=None):
     """Creates target bags to be picked up by a TransferRoutine based on a string.
-    # This allows processing of bags serialized in multiple formats at once."""
+    This allows processing of bags serialized in multiple formats at once."""
     moved_bags = []
     target_bags = [b for b in listdir(test_bags_dir) if b.startswith(target_str)]
     if len(target_bags) < 1:

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -8,7 +8,8 @@ from aurora import settings
 from bag_transfer.lib import files_helper as FH
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
-                                 Archives, BagItProfile, BagItProfileBagInfo,
+                                 Archives, BagInfoMetadata, BagItProfile,
+                                 BagItProfileBagInfo,
                                  BagItProfileBagInfoValues, LanguageCode,
                                  ManifestsAllowed, ManifestsRequired,
                                  Organization, RecordCreators,
@@ -156,27 +157,6 @@ def create_test_user(username=None, password=None, org=None, groups=[], is_staff
     test_user.save()
     print("Test user {username} created".format(username=username))
     return test_user
-
-
-def create_test_archive(transfer, org):
-    """Creates Archive objects by running bags through TransferRoutine."""
-    machine_file_identifier = Archives().gen_identifier()
-    archive = Archives.initial_save(
-        org,
-        None,
-        transfer["file_path"],
-        transfer["file_size"],
-        transfer["file_modtime"],
-        machine_file_identifier,
-        transfer["file_type"],
-        transfer["bag_it_name"],
-    )
-
-    # updating the name since the bag info reflects ford
-    archive.organization.name = "Ford Foundation"
-    archive.organization.save()
-
-    return archive
 
 
 def create_target_bags(target_str, test_bags_dir, org, username=None):
@@ -445,6 +425,27 @@ def create_test_bagitprofilebaginfovalues(baginfo=None):
         bag_info_value.save()
         values.append(bag_info_value)
     return values
+
+
+def create_test_baginfometadatas(archive, organization=None, count=1):
+    metadatas = []
+    organization = organization if organization else random.choice(Organization.objects.all())
+    for x in range(count):
+        baginfo = BagInfoMetadata.objects.create(
+            archive=archive,
+            source_organization=organization,
+            external_identifier=random_string(20),
+            internal_sender_description=random_string(50),
+            title=random_string(15),
+            date_start=make_aware(random_date(1960)),
+            date_end=make_aware(random_date(1970)),
+            record_type=random.choice(org_setup.record_types),
+            bagging_date=make_aware(datetime.now()),
+            bag_count=1,
+            bag_group_identifier=random.randint(1, 5),
+            payload_oxum=random.randint(0, 100),
+            bagit_profile_identifier="http://www.example.com")
+        metadatas.append(baginfo)
 
 
 def create_test_record_creators(count=1):

--- a/aurora/bag_transfer/test/setup.py
+++ b/aurora/bag_transfer/test/setup.py
@@ -66,7 +66,11 @@ user_data = {
     "email": "test@example.org",
 }
 
-org_data = {"active": True, "name": "Test Organization", "acquisition_type": "donation"}
+org_data = {
+    "active": True,
+    "name": "Test Organization",
+    "acquisition_type": "donation"
+}
 
 # Variables and setup routines for RightsStatements
 

--- a/aurora/bag_transfer/test/setup.py
+++ b/aurora/bag_transfer/test/setup.py
@@ -5,7 +5,7 @@ from bag_transfer.rights.models import (RightsStatementCopyright,
                                         RightsStatementOther,
                                         RightsStatementStatute)
 
-POTUS_NAMES = ["Ford", "Obama", "Trump", "Bush", "Clinton"]
+POTUS_NAMES = ["Ford", "Obama", "Bush", "Clinton", "Roosevelt"]
 COMPANY_SUFFIX = ["Foundation", "Group", "Org"]
 TEST_ORG_COUNT = 3
 

--- a/aurora/bag_transfer/test/test_accessioning.py
+++ b/aurora/bag_transfer/test/test_accessioning.py
@@ -25,8 +25,7 @@ class AccessioningTestCase(TestCase):
             password=settings.TEST_USER["PASSWORD"])
         self.client.login(
             username=settings.TEST_USER["USERNAME"],
-            password=settings.TEST_USER["PASSWORD"]
-        )
+            password=settings.TEST_USER["PASSWORD"])
 
     def test_accessioning(self):
         id_list = ",".join([str(archive.id) for archive in self.archives])

--- a/aurora/bag_transfer/test/test_api.py
+++ b/aurora/bag_transfer/test/test_api.py
@@ -17,7 +17,10 @@ class APITest(TestCase):
         self.archivesspace_identifier = "/repositories/2/archival_objects/3"
         self.archivesspace_parent_identifier = "/repositories/2/archival_objects/4"
         self.orgs = helpers.create_test_orgs(org_count=1)
-        helpers.create_test_archives(organization=self.orgs[0], count=10)
+        helpers.create_test_archives(
+            organization=self.orgs[0],
+            process_status=Archives.ACCEPTED,
+            count=10)
         self.user = helpers.create_test_user(
             username=settings.TEST_USER["USERNAME"],
             password=settings.TEST_USER["PASSWORD"],

--- a/aurora/bag_transfer/test/test_api.py
+++ b/aurora/bag_transfer/test/test_api.py
@@ -1,6 +1,5 @@
-import os
 import random
-import shutil
+from unittest.mock import patch
 
 from aurora import settings
 from bag_transfer.api.views import ArchivesViewSet
@@ -18,91 +17,53 @@ class APITest(TestCase):
         self.archivesspace_identifier = "/repositories/2/archival_objects/3"
         self.archivesspace_parent_identifier = "/repositories/2/archival_objects/4"
         self.orgs = helpers.create_test_orgs(org_count=1)
+        helpers.create_test_archives(organization=self.orgs[0], count=10)
         self.user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"], org=random.choice(self.orgs)
-        )
-        self.user.is_staff = True
-        self.user.set_password(settings.TEST_USER["PASSWORD"])
-        self.user.save()
-        self.bags = helpers.create_target_bags(
-            "valid_bag", settings.TEST_BAGS_DIR, self.orgs[0]
-        )
-        tr = helpers.run_transfer_routine()
-        self.archives = []
-        for transfer in tr.transfers:
-            archive = helpers.create_test_archive(transfer, self.orgs[0])
-            self.archives.append(archive)
-        for archive in self.archives:
-            shutil.copy(
-                os.path.join(
-                    settings.BASE_DIR, settings.TEST_BAGS_DIR, "valid_bag.tar.gz"
-                ),
-                os.path.join(
-                    settings.BASE_DIR,
-                    settings.DELIVERY_QUEUE_DIR,
-                    "{}.tar.gz".format(archive.machine_file_identifier),
-                ),
-            )
+            username=settings.TEST_USER["USERNAME"],
+            password=settings.TEST_USER["PASSWORD"],
+            org=random.choice(self.orgs),
+            is_staff=True)
 
-    def update_transfer(self):
+    @patch("bag_transfer.lib.cleanup.CleanupRoutine.run")
+    def update_transfer(self, mock_cleanup):
         for archive in Archives.objects.all():
             request = self.factory.get(
-                reverse("archives-detail", kwargs={"pk": archive.pk}), format="json"
-            )
+                reverse("archives-detail", kwargs={"pk": archive.pk}), format="json")
             request.user = self.user
-            new_transfer = ArchivesViewSet.as_view(actions={"get": "retrieve"})(
-                request, pk=archive.pk
-            ).data
-            new_transfer["process_status"] = self.process_status
-            new_transfer["archivesspace_identifier"] = self.archivesspace_identifier
-            new_transfer[
-                "archivesspace_parent_identifier"
-            ] = self.archivesspace_parent_identifier
+            new_transfer = ArchivesViewSet.as_view(
+                actions={"get": "retrieve"})(request, pk=archive.pk).data
+            for field in ["process_status", "archivesspace_identifier", "archivesspace_parent_identifier"]:
+                new_transfer[field] = getattr(self, field)
 
             request = self.factory.put(
                 reverse("archives-detail", kwargs={"pk": archive.pk}),
                 data=new_transfer,
-                format="json",
-            )
+                format="json")
             request.user = self.user
-            response = ArchivesViewSet.as_view(actions={"put": "update"})(
-                request, pk=archive.pk
-            )
+            response = ArchivesViewSet.as_view(
+                actions={"put": "update"})(request, pk=archive.pk)
             self.assertEqual(response.status_code, 200, "Wrong HTTP status code")
-            for field in [
-                "process_status",
-                "archivesspace_identifier",
-                "archivesspace_parent_identifier",
-            ]:
+            for field in ["process_status", "archivesspace_identifier", "archivesspace_parent_identifier"]:
                 self.assertEqual(
                     response.data[field],
                     getattr(self, field),
                     "{} status not updated".format(field),
                 )
-            self.assertEqual(
-                False,
-                os.path.isfile(
-                    os.path.join(
-                        settings.BASE_DIR,
-                        settings.DELIVERY_QUEUE_DIR,
-                        "{}.tar.gz".format(new_transfer["identifier"]),
-                    )
-                ),
-                "File was not removed",
-            )
+            mock_cleanup.assert_called_once()
+            mock_cleanup.reset_mock()
 
-    def schema(self):
+    def schema_response(self):
         schema = self.client.get(reverse("schema"))
         self.assertEqual(schema.status_code, 200, "Wrong HTTP code")
 
-    def health_check(self):
+    def health_check_response(self):
         status = self.client.get(reverse('api_health_ping'))
         self.assertEqual(status.status_code, 200, "Wrong HTTP code")
 
     def test_api(self):
         self.update_transfer()
-        self.schema()
-        self.health_check()
+        self.schema_response()
+        self.health_check_response()
 
     def tearDown(self):
         helpers.delete_test_orgs(self.orgs)

--- a/aurora/bag_transfer/test/test_appraisal.py
+++ b/aurora/bag_transfer/test/test_appraisal.py
@@ -11,100 +11,71 @@ class AppraisalTestCase(TestCase):
     def setUp(self):
         self.client = Client()
         self.orgs = helpers.create_test_orgs(org_count=1)
-        self.bags = helpers.create_target_bags(
-            "valid_bag", settings.TEST_BAGS_DIR, self.orgs[0]
-        )
-        tr = helpers.run_transfer_routine()
-        self.archives = []
-        for transfer in tr.transfers:
-            archive = helpers.create_test_archive(transfer, self.orgs[0])
-            self.archives.append(archive)
+        self.archives = helpers.create_test_archives(
+            organization=self.orgs[0],
+            process_status=Archives.VALIDATED,
+            count=10)
         self.groups = helpers.create_test_groups(["appraisal_archivists"])
         self.user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"], org=random.choice(self.orgs)
-        )
-        for group in self.groups:
-            self.user.groups.add(group)
-        self.user.is_staff = True
-        self.user.set_password(settings.TEST_USER["PASSWORD"])
-        self.user.save()
-
-    def test_appraisal(self):
-        for archive in self.archives:
-            archive.process_status = Archives.VALIDATED
-            archive.save()
-
-        # Test GET views
+            username=settings.TEST_USER["USERNAME"],
+            password=settings.TEST_USER["PASSWORD"],
+            org=random.choice(self.orgs),
+            is_staff=True,
+            groups=self.groups)
         self.client.login(
-            username=self.user.username, password=settings.TEST_USER["PASSWORD"]
-        )
+            username=self.user.username, password=settings.TEST_USER["PASSWORD"])
+
+    def list_views(self):
         response = self.client.get(reverse("appraise:list"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["uploads_count"], len(self.archives))
 
-        # Accept/Reject archives
-        accept_archive = random.choice(
-            Archives.objects.filter(process_status=Archives.VALIDATED)
-        )
-        accept_request = self.client.get(
-            reverse("appraise:list"),
-            {
-                "req_form": "appraise",
-                "req_type": "decision",
-                "upload_id": accept_archive.pk,
-                "appraisal_decision": 1,
-            },
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        self.assertEqual(accept_request.status_code, 200)
-        resp = accept_request.json()
-        self.assertEqual(resp["success"], 1)
-        reject_archive = random.choice(
-            Archives.objects.filter(process_status=Archives.VALIDATED)
-        )
-        reject_request = self.client.get(
-            reverse("appraise:list"),
-            {
-                "req_form": "appraise",
-                "req_type": "decision",
-                "upload_id": reject_archive.pk,
-                "appraisal_decision": 0,
-            },
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        resp = reject_request.json()
-        self.assertEqual(resp["success"], 1)
+    def accept_or_reject(self):
+        """Tests accept or reject decisions."""
+        for decision in [1, 0]:
+            archive = random.choice(Archives.objects.all())
+            request = self.client.get(
+                reverse("appraise:list"),
+                {
+                    "req_form": "appraise",
+                    "req_type": "decision",
+                    "upload_id": archive.pk,
+                    "appraisal_decision": decision,
+                },
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",)
+            self.assertEqual(request.status_code, 200)
+            self.assertEqual(request.json()["success"], 1)
 
-        # Submit and Edit appraisal note
-        note_archive = random.choice(
-            Archives.objects.filter(process_status=Archives.VALIDATED)
-        )
-        submit_note_request = self.client.get(
-            reverse("appraise:list"),
-            {
-                "req_form": "appraise",
-                "req_type": "submit",
-                "upload_id": note_archive.pk,
-                "appraisal_note": "Test appraisal note",
-            },
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        resp = submit_note_request.json()
-        self.assertEqual(resp["success"], 1)
-        updated_archive = Archives.objects.get(pk=note_archive.pk)
-        self.assertEqual(updated_archive.appraisal_note, "Test appraisal note")
-        edit_note_request = self.client.get(
-            reverse("appraise:list"),
-            {"req_form": "appraise", "req_type": "edit", "upload_id": note_archive.pk},
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        resp = edit_note_request.json()
-        self.assertEqual(resp["success"], 1)
-        self.assertEqual(resp["appraisal_note"], "Test appraisal note")
+    def appraisal_note(self):
+        """Tests submission and editing of appraisal note."""
+        archive = random.choice(
+            Archives.objects.filter(process_status=Archives.VALIDATED))
+        note_text = helpers.random_string(30)
+        for req_type in ["submit", "edit"]:
+            request = self.client.get(
+                reverse("appraise:list"),
+                {
+                    "req_form": "appraise",
+                    "req_type": req_type,
+                    "upload_id": archive.pk,
+                    "appraisal_note": note_text,
+                },
+                HTTP_X_REQUESTED_WITH="XMLHttpRequest",)
+            self.assertEqual(request.json()["success"], 1)
+            updated = Archives.objects.get(pk=archive.pk)
+            self.assertEqual(updated.appraisal_note, note_text)
+            if request.json().get("appraisal_note"):
+                self.assertEqual(request.json()["appraisal_note"], note_text)
 
-        # Make sure appraised archives are no longer in this view
+    def list_count(self):
         response = self.client.get(reverse("appraise:list"))
         self.assertEqual(response.context["uploads_count"], len(self.archives) - 2)
+
+    def test_appraisal(self):
+        self.list_views()
+        self.accept_or_reject()
+        self.appraisal_note()
+        self.list_count()
 
     def tearDown(self):
         helpers.delete_test_orgs(self.orgs)

--- a/aurora/bag_transfer/test/test_bagitprofiles.py
+++ b/aurora/bag_transfer/test/test_bagitprofiles.py
@@ -1,6 +1,5 @@
 import random
 
-from bag_transfer.lib.bag_checker import bagChecker
 from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
                                  BagItProfile, BagItProfileBagInfo,
                                  ManifestsAllowed, ManifestsRequired,
@@ -194,14 +193,6 @@ class BagItProfileTestCase(TestCase):
             },
         )
         self.assertEqual(update_request.status_code, 302, "Request was not redirected")
-
-        # Ensure bags are validated
-        helpers.create_target_bags("valid_bag", settings.TEST_BAGS_DIR, self.orgs[0])
-        tr = helpers.run_transfer_routine()
-        for transfer in tr.transfers:
-            archive = helpers.create_test_archive(transfer, self.orgs[0])
-            test_bag = bagChecker(archive)
-            self.assertTrue(test_bag.bag_passed_all())
 
         # Delete bagit profile
         delete_request = self.client.get(

--- a/aurora/bag_transfer/test/test_bagitprofiles.py
+++ b/aurora/bag_transfer/test/test_bagitprofiles.py
@@ -16,29 +16,22 @@ class BagItProfileTestCase(TestCase):
     def setUp(self):
         self.client = Client()
         self.orgs = helpers.create_test_orgs(org_count=1)
-        self.groups = helpers.create_test_groups(["managing_archivists"])
         self.user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"], org=random.choice(self.orgs)
-        )
-        for group in self.groups:
-            self.user.groups.add(group)
-        self.user.org = self.orgs[0]
-        self.user.is_staff = True
-        self.user.set_password(settings.TEST_USER["PASSWORD"])
-        self.user.save()
+            username=settings.TEST_USER["USERNAME"],
+            password=settings.TEST_USER["PASSWORD"],
+            org=random.choice(self.orgs),
+            groups=helpers.create_test_groups(["managing_archivists"]),
+            is_staff=True)
+        self.client.login(
+            username=self.user.username, password=settings.TEST_USER["PASSWORD"])
         self.bagitprofiles = []
         self.baginfos = []
 
     def test_bagitprofiles(self):
-        self.client.login(
-            username=self.user.username, password=settings.TEST_USER["PASSWORD"]
-        )
-
         for org in self.orgs:
             profile = helpers.create_test_bagitprofile(applies_to_organization=org)
             response = self.client.get(
-                reverse("bagitprofile-detail", kwargs={"pk": profile.pk})
-            )
+                reverse("bagitprofile-detail", kwargs={"pk": profile.pk}))
             self.assertEqual(response.status_code, 200)
             self.bagitprofiles.append(profile)
         self.assertEqual(len(self.bagitprofiles), len(self.orgs))
@@ -52,12 +45,10 @@ class BagItProfileTestCase(TestCase):
             helpers.create_test_tagfilesrequired(bagitprofile=profile)
             for field in BAGINFO_FIELD_CHOICES:
                 baginfo = helpers.create_test_bagitprofilebaginfo(
-                    bagitprofile=profile, field=field
-                )
+                    bagitprofile=profile, field=field)
                 self.baginfos.append(baginfo)
             self.assertEqual(
-                len(BagItProfileBagInfo.objects.all()), len(BAGINFO_FIELD_CHOICES)
-            )
+                len(BagItProfileBagInfo.objects.all()), len(BAGINFO_FIELD_CHOICES))
 
             for info in self.baginfos:
                 helpers.create_test_bagitprofilebaginfovalues(baginfo=info)
@@ -109,7 +100,7 @@ class BagItProfileTestCase(TestCase):
             reverse("orgs:bagit-profiles-add", kwargs={"pk": organization.pk}),
             {
                 "contact_email": "archive@rockarch.org",
-                "source_organization": self.user.org.pk,
+                "source_organization": organization.pk,
                 "applies_to_organization": organization.pk,
                 "allow_fetch": random.choice([True, False]),
                 "external_description": helpers.random_string(100),
@@ -154,11 +145,10 @@ class BagItProfileTestCase(TestCase):
         update_request = self.client.post(
             reverse(
                 "orgs:bagit-profiles-edit",
-                kwargs={"pk": organization.pk, "profile_pk": profile.pk},
-            ),
+                kwargs={"pk": organization.pk, "profile_pk": profile.pk}),
             {
                 "contact_email": "archive@rockarch.org",
-                "source_organization": self.user.org.pk,
+                "source_organization": organization.pk,
                 "applies_to_organization": organization.pk,
                 "allow_fetch": random.choice([True, False]),
                 "external_description": helpers.random_string(100),

--- a/aurora/bag_transfer/test/test_bags.py
+++ b/aurora/bag_transfer/test/test_bags.py
@@ -8,11 +8,11 @@ from bag_transfer.models import Archives, BAGLog, Organization, User
 from bag_transfer.test import helpers
 from bag_transfer.test.setup import BAGS_REF, TEST_ORG_COUNT
 from django.conf import settings
-from django.test import Client, TransactionTestCase
+from django.test import Client, TestCase
 from django.urls import reverse
 
 
-class BagTestCase(TransactionTestCase):
+class BagTestCase(TestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=TEST_ORG_COUNT)
         self.user = helpers.create_test_user(
@@ -64,7 +64,17 @@ class BagTestCase(TransactionTestCase):
                 # END --  TEST RESULTS OF RUN ROUTINE
                 ###############
 
-                archive = helpers.create_test_archive(trans, self.orgs[0])
+                archive = Archives.initial_save(
+                    self.orgs[0],
+                    None,
+                    trans["file_path"],
+                    trans["file_size"],
+                    trans["file_modtime"],
+                    Archives().gen_identifier(),
+                    trans["file_type"],
+                    trans["bag_it_name"])
+                archive.organization.name = "Ford Foundation"
+                archive.organization.save()
 
                 # checks if this is unique which it should not already be in the system
                 self.assertIsNot(False, archive.machine_file_identifier)

--- a/aurora/bag_transfer/test/test_bags.py
+++ b/aurora/bag_transfer/test/test_bags.py
@@ -15,16 +15,12 @@ from django.urls import reverse
 class BagTestCase(TransactionTestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=TEST_ORG_COUNT)
-        self.baglogcodes = helpers.create_test_baglogcodes()
-        self.groups = helpers.create_test_groups(["managing_archivists"])
         self.user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"], org=random.choice(self.orgs)
-        )
-        for group in self.groups:
-            self.user.groups.add(group)
-        self.user.is_staff = True
-        self.user.set_password(settings.TEST_USER["PASSWORD"])
-        self.user.save()
+            username=settings.TEST_USER["USERNAME"],
+            password=settings.TEST_USER["PASSWORD"],
+            org=random.choice(self.orgs),
+            groups=helpers.create_test_groups(["managing_archivists"]),
+            is_staff=True)
         self.client = Client()
 
     def test_bags(self):
@@ -82,8 +78,7 @@ class BagTestCase(TransactionTestCase):
 
                 # deleting path in processing and tmp dir
                 remove_file_or_dir(
-                    os.path.join(settings.TRANSFER_EXTRACT_TMP, archive.bag_it_name)
-                )
+                    os.path.join(settings.TRANSFER_EXTRACT_TMP, archive.bag_it_name))
                 remove_file_or_dir(archive.machine_file_path)
 
                 ###############
@@ -125,33 +120,25 @@ class BagTestCase(TransactionTestCase):
                 resp = self.client.get(
                     reverse(
                         "organization-detail",
-                        kwargs={"pk": random.choice(Organization.objects.all()).pk},
-                    )
-                )
+                        kwargs={"pk": random.choice(Organization.objects.all()).pk}))
                 self.assertEqual(resp.status_code, 200)
 
                 resp = self.client.get(
                     reverse(
                         "archives-detail",
-                        kwargs={"pk": random.choice(Archives.objects.all()).pk},
-                    )
-                )
+                        kwargs={"pk": random.choice(Archives.objects.all()).pk}))
                 self.assertEqual(resp.status_code, 200)
 
                 resp = self.client.get(
                     reverse(
                         "baglog-detail",
-                        kwargs={"pk": random.choice(BAGLog.objects.all()).pk},
-                    )
-                )
+                        kwargs={"pk": random.choice(BAGLog.objects.all()).pk}))
                 self.assertEqual(resp.status_code, 200)
 
                 resp = self.client.get(
                     reverse(
                         "user-detail",
-                        kwargs={"pk": random.choice(User.objects.all()).pk},
-                    )
-                )
+                        kwargs={"pk": random.choice(User.objects.all()).pk}))
                 self.assertEqual(resp.status_code, 200)
 
     def tearDown(self):

--- a/aurora/bag_transfer/test/test_cron.py
+++ b/aurora/bag_transfer/test/test_cron.py
@@ -13,22 +13,25 @@ from django.test import Client, TransactionTestCase
 class CronTestCase(TransactionTestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=1)
-        self.baglogcodes = helpers.create_test_baglogcodes()
-        self.groups = helpers.create_test_groups(['managing_archivists'])
-        self.user = helpers.create_test_user(username=settings.TEST_USER['USERNAME'], org=random.choice(self.orgs))
-        for group in self.groups:
-            self.user.groups.add(group)
-        self.user.is_staff = True
-        self.user.set_password(settings.TEST_USER['PASSWORD'])
-        self.user.save()
+        self.user = helpers.create_test_user(
+            username=settings.TEST_USER['USERNAME'],
+            password=settings.TEST_USER['PASSWORD'],
+            org=random.choice(self.orgs),
+            groups=helpers.create_test_groups(['managing_archivists']),
+            is_staff=True)
         self.client = Client()
 
     def test_cron(self):
+        self.discover_bags()
+        self.deliver_bags()
+
+    def discover_bags(self):
         for ref in BAGS_REF:
             helpers.create_target_bags(ref[0], settings.TEST_BAGS_DIR, self.orgs[0], username=self.user.username)
         discovered = DiscoverTransfers().do()
         self.assertIsNot(False, discovered)
 
+    def deliver_bags(self):
         for archive in Archives.objects.filter(process_status=Archives.VALIDATED):
             archive.process_status = Archives.ACCESSIONING_STARTED
             archive.save()
@@ -41,7 +44,8 @@ class CronTestCase(TransactionTestCase):
         )
         for bag_path in os.listdir(settings.DELIVERY_QUEUE_DIR):
             bag = bagit.Bag(os.path.join(settings.DELIVERY_QUEUE_DIR, bag_path))
-            self.assertTrue('Origin' in bag.bag_info)
+            self.assertTrue("Origin" in bag.bag_info)
+            self.assertEqual(bag.bag_info["Origin"], "aurora")
 
     def tearDown(self):
         helpers.delete_test_orgs(self.orgs)

--- a/aurora/bag_transfer/test/test_cron.py
+++ b/aurora/bag_transfer/test/test_cron.py
@@ -7,10 +7,10 @@ from bag_transfer.models import Archives
 from bag_transfer.test import helpers
 from bag_transfer.test.setup import BAGS_REF
 from django.conf import settings
-from django.test import Client, TransactionTestCase
+from django.test import Client, TestCase
 
 
-class CronTestCase(TransactionTestCase):
+class CronTestCase(TestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=1)
         self.user = helpers.create_test_user(
@@ -40,8 +40,7 @@ class CronTestCase(TransactionTestCase):
         self.assertEqual(len(Archives.objects.filter(process_status=Archives.ACCESSIONING_STARTED)), 0)
         self.assertEqual(
             len(Archives.objects.filter(process_status=Archives.DELIVERED)),
-            len(os.listdir(settings.DELIVERY_QUEUE_DIR))
-        )
+            len(os.listdir(settings.DELIVERY_QUEUE_DIR)))
         for bag_path in os.listdir(settings.DELIVERY_QUEUE_DIR):
             bag = bagit.Bag(os.path.join(settings.DELIVERY_QUEUE_DIR, bag_path))
             self.assertTrue("Origin" in bag.bag_info)

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -3,10 +3,10 @@ import random
 from bag_transfer.lib.files_helper import remove_file_or_dir
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.test import helpers
-from django.test import TransactionTestCase
+from django.test import TestCase
 
 
-class TransferRoutineTestCase(TransactionTestCase):
+class TransferRoutineTestCase(TestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=3)
 

--- a/aurora/bag_transfer/test/test_users_orgs.py
+++ b/aurora/bag_transfer/test/test_users_orgs.py
@@ -13,107 +13,46 @@ class UserOrgTestCase(TestCase):
     def setUp(self):
         self.client = Client()
         self.orgs = helpers.create_test_orgs(org_count=org_count)
-        self.bags = helpers.create_target_bags(
-            "valid_bag", settings.TEST_BAGS_DIR, self.orgs[0]
-        )
-        tr = helpers.run_transfer_routine()
-        self.archives = []
-        for transfer in tr.transfers:
-            archive = helpers.create_test_archive(transfer, self.orgs[0])
-            self.archives.append(archive)
 
-    def test_users(self):
-        for user in (
-            ("donor", "donor"),
-            ("managing_archivists", "manager"),
-            ("appraisal_archivists", "appraiser"),
-            ("accessioning_archivists", "accessioner"),
-        ):
-            groups = helpers.create_test_groups([user[0]])
+    def create_users(self):
+        for group, username in [("donor", "donor"),
+                                ("managing_archivists", "manager"),
+                                ("appraisal_archivists", "appraiser"),
+                                ("accessioning_archivists", "accessioner")]:
+            is_staff = False if group == "donor" else True
             user = helpers.create_test_user(
-                username=user[1], org=random.choice(self.orgs)
-            )
-            for group in groups:
-                user.groups.add(group)
-                if group.name in [
-                    "managing_archivists",
-                    "appraisal_archivists",
-                    "accessioning_archivists",
-                ]:
-                    user.is_staff = True
-                    user.set_password(settings.TEST_USER["PASSWORD"])
-                    user.save()
+                username=username,
+                password=settings.TEST_USER["PASSWORD"],
+                org=random.choice(self.orgs),
+                groups=helpers.create_test_groups([group]),
+                is_staff=is_staff)
 
-        # Username, assertTrue methods, assertFalse methods
-        user_list = (
-            ("donor", [], ["is_archivist", "can_appraise", "is_manager"], ""),
-            ("manager", ["is_archivist", "can_appraise", "is_manager"], [], "MANAGING"),
-            (
-                "accessioner",
-                ["is_archivist"],
-                ["can_appraise", "is_manager"],
-                "ACCESSIONER",
-            ),
-            (
-                "appraiser",
-                ["is_archivist", "can_appraise"],
-                ["is_manager"],
-                "APPRAISER",
-            ),
-        )
-        for u in user_list:
-            user = User.objects.get(username=u[0])
-            for meth in u[1]:
+        for username, assert_true, assert_false, privs in [
+                ("donor", [], ["is_archivist", "can_appraise", "is_manager"], None),
+                ("manager", ["is_archivist", "can_appraise", "is_manager"], [], "MANAGING"),
+                ("accessioner", ["is_archivist"], ["can_appraise", "is_manager"], "ACCESSIONER"),
+                ("appraiser", ["is_archivist", "can_appraise"], ["is_manager"], "APPRAISER")]:
+            user = User.objects.get(username=username)
+            for meth in assert_true:
                 self.assertTrue(
                     getattr(user, meth)(),
-                    "User {} is unable to perform function {}".format(user, meth),
-                )
-            for meth in u[2]:
+                    "User {} is unable to perform function {}".format(user, meth))
+            for meth in assert_false:
                 self.assertFalse(
                     getattr(user, meth)(),
                     "User {} should not be able to perform function {}".format(
-                        user, meth
-                    ),
-                )
-            if len(u[3]) > 1:
-                self.assertTrue(user.has_privs(u[3]))
-
-        # Test user views
-        self.user_views()
-
-    def test_orgs(self):
-        groups = helpers.create_test_groups(["managing_archivists"])
-        user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"], org=random.choice(self.orgs)
-        )
-        for group in groups:
-            user.groups.add(group)
-        user.is_staff = True
-        user.set_password(settings.TEST_USER["PASSWORD"])
-        user.save()
-        self.client.login(
-            username=user.username, password=settings.TEST_USER["PASSWORD"]
-        )
-
-        # Test Org views
-        self.org_views()
-        for org in Organization.objects.all():
-            if org not in self.orgs:
-                self.orgs.append(org)
-
-    def tearDown(self):
-        helpers.delete_test_orgs(self.orgs)
+                        user, meth))
+            if privs:
+                self.assertTrue(user.has_privs(privs))
 
     def user_views(self):
         user = User.objects.get(groups__name="managing_archivists")
         self.client.login(
-            username=user.username, password=settings.TEST_USER["PASSWORD"]
-        )
+            username=user.username, password=settings.TEST_USER["PASSWORD"])
 
         for view in ["users:detail", "users:edit"]:
             response = self.client.get(
-                reverse(view, kwargs={"pk": random.choice(User.objects.all()).pk})
-            )
+                reverse(view, kwargs={"pk": random.choice(User.objects.all()).pk}))
             self.assertEqual(response.status_code, 200)
 
         response = self.client.get(reverse("users:add"))
@@ -128,27 +67,40 @@ class UserOrgTestCase(TestCase):
         user_data["active"] = False
         response = self.client.post(
             reverse("users:edit", kwargs={"pk": random.choice(User.objects.all()).pk}),
-            user_data,
-        )
+            user_data)
         self.assertTrue(response.status_code, 200)
 
-    def org_views(self):
+    def test_orgs(self):
+        helpers.create_test_user(
+            username="manager",
+            password=settings.TEST_USER["PASSWORD"],
+            org=random.choice(self.orgs),
+            groups=helpers.create_test_groups(["managing_archivists"]),
+            is_staff=True)
+        self.client.login(
+            username="manager", password=settings.TEST_USER["PASSWORD"])
         response = self.client.get(reverse("orgs:list"))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context["object_list"]), org_count)
         for view in ["orgs:detail", "orgs:edit"]:
             response = self.client.get(
-                reverse(view, kwargs={"pk": random.choice(self.orgs).pk})
-            )
+                reverse(view, kwargs={"pk": random.choice(self.orgs).pk}))
             self.assertEqual(response.status_code, 200)
 
         org_data = setup.org_data
+        org_data["name"] = "New Test Organization"
         response = self.client.post(reverse("orgs:add"), org_data)
         self.assertTrue(response.status_code, 200)
 
         # make org inactive
         org_data["active"] = False
         response = self.client.post(
-            reverse("orgs:edit", kwargs={"pk": random.choice(self.orgs).pk}), org_data
-        )
+            reverse("orgs:edit", kwargs={"pk": random.choice(self.orgs).pk}), org_data)
         self.assertTrue(response.status_code, 200)
+
+    def test_users(self):
+        self.create_users()
+        self.user_views()
+
+    def tearDown(self):
+        helpers.delete_test_orgs(Organization.objects.all())


### PR DESCRIPTION
Improves two broadly-used test helper methods: `create_test_user` and `create_test_archives` to factor out consistently-used logic and avoid running expensive functions (`transferRoutine`) when that is not necessary. A number of other changes were made to tests to incorporate these changes and try to improve their readability and clarity.

fixes #380