### PR TITLE
Adds clamav script

### DIFF
--- a/scripts/test3310.sh
+++ b/scripts/test3310.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Script to check that clamd is running on port 3310.  If not, restart clamd service
+#
+#log_file="/data/logs/clamd/clamd.log"
+date_this_run=$(date)
+var=$(lsof -t -itcp:3310)
+if [ $? = 1 ]; then
+# Need to restart clamd service as it is not running
+  systemctl restart clamd
+  echo $date_this_run' - Clamd was NOT running - service restarted'
+else
+  echo $date_this_run' - Clamd was running - no action taken'
+fi


### PR DESCRIPTION
Adds a script which checks to see if clamav is active on port 3310. This can be configured to run using a cronjob.