### PR TITLE
Updates travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-python: 2.7
-sudo: required
 services:
   - docker
 env:


### PR DESCRIPTION
Removes two keys from Travis CI config:
- `sudo` - deprecated key which has no effect
- `python` - which specified Python 2, which Aurora no longer uses.

fixes #422 