### PR TITLE
Replace functions in files_helpers that are in asterism

### DIFF
--- a/aurora/bag_transfer/appraise/views.py
+++ b/aurora/bag_transfer/appraise/views.py
@@ -1,4 +1,4 @@
-from bag_transfer.lib.files_helper import remove_file_or_dir
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.mailer import Mailer
 from bag_transfer.mixins.authmixins import ArchivistMixin
 from bag_transfer.mixins.formatmixins import JSONResponseMixin

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -1,6 +1,7 @@
 import glob
 import json
 from os.path import isfile
+from asterism.file_helpers import zip_extract_all, tar_extract_all, dir_extract_all
 
 import bagit
 import bagit_profile
@@ -26,13 +27,13 @@ class bagChecker:
 
     def _extract_archive(self):
         if self.archiveObj.machine_file_type == "TAR":
-            if not FH.tar_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
+            if not tar_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
                 return False
         elif self.archiveObj.machine_file_type == "ZIP":
-            if not FH.zip_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
+            if not zip_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
                 return False
         elif self.archiveObj.machine_file_type == "OTHER":
-            if not FH.dir_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
+            if not dir_extract_all(self.archiveObj.machine_file_path, self.tmp_path):
                 return False
         else:
             return False

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -1,11 +1,12 @@
 import glob
 import json
 from os.path import isfile
-from asterism.file_helpers import zip_extract_all, tar_extract_all, dir_extract_all
 
 import bagit
 import bagit_profile
 import iso8601
+from asterism.file_helpers import (dir_extract_all, tar_extract_all,
+                                   zip_extract_all)
 from bag_transfer.lib import files_helper as FH
 from bag_transfer.models import BAGLog
 from django.conf import settings

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -1,6 +1,8 @@
 import json
 from os import mkdir
 from os.path import join
+from asterism.file_helpers import remove_file_or_dir
+
 
 import bag_transfer.lib.log_print as Pter
 from aurora import settings
@@ -60,7 +62,7 @@ class DiscoverTransfers(CronJobBase):
                         BAGLog.log_it(upload_list["auto_fail_code"], new_arc)
                         email.setup_message("TRANS_FAIL_VAL", new_arc)
                         email.send()
-                        FH.remove_file_or_dir(new_arc.machine_file_path)
+                        remove_file_or_dir(new_arc.machine_file_path)
 
                     else:
                         bag = bagChecker(new_arc)
@@ -82,7 +84,7 @@ class DiscoverTransfers(CronJobBase):
                                     new_arc.machine_file_identifier,
                                 ),
                             )
-                            FH.remove_file_or_dir(new_arc.machine_file_path)
+                            remove_file_or_dir(new_arc.machine_file_path)
                             new_arc.machine_file_path = "{}{}".format(
                                 settings.STORAGE_ROOT_DIR, new_arc.machine_file_identifier
                             )
@@ -96,10 +98,10 @@ class DiscoverTransfers(CronJobBase):
                             BAGLog.log_it(bag.ecode, new_arc)
                             email.setup_message("TRANS_FAIL_VAL", new_arc)
                             email.send()
-                            FH.remove_file_or_dir(new_arc.machine_file_path)
+                            remove_file_or_dir(new_arc.machine_file_path)
 
                     new_arc.save()
-                    FH.remove_file_or_dir("/data/tmp/{}".format(new_arc.bag_it_name))
+                    remove_file_or_dir("/data/tmp/{}".format(new_arc.bag_it_name))
                 except Exception as e:
                     print("Error discovering transfer {}: {}".format(machine_file_identifier, str(e)))
                     result = False
@@ -164,7 +166,7 @@ class DeliverTransfers(CronJobBase):
                     join(settings.DELIVERY_QUEUE_DIR, archive.machine_file_identifier),
                 )
 
-                FH.remove_file_or_dir(
+                remove_file_or_dir(
                     join(settings.DELIVERY_QUEUE_DIR, archive.machine_file_identifier)
                 )
 

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -2,12 +2,12 @@ import json
 from os import mkdir
 from os.path import join
 from asterism.file_helpers import remove_file_or_dir, move_file_or_dir, make_tarfile
+from asterism.bagit_helpers import update_bag_info
 
 
 import bag_transfer.lib.log_print as Pter
 from aurora import settings
 from bag_transfer.api.serializers import ArchivesSerializer
-from bag_transfer.lib import files_helper as FH
 from bag_transfer.lib.bag_checker import bagChecker
 from bag_transfer.lib.mailer import Mailer
 from bag_transfer.lib.transfer_routine import TransferRoutine
@@ -122,7 +122,7 @@ class DeliverTransfers(CronJobBase):
             process_status=Archives.ACCESSIONING_STARTED
         ):
             try:
-                FH.update_bag_info(
+                update_bag_info(
                     join(settings.STORAGE_ROOT_DIR, archive.machine_file_identifier),
                     {"Origin": "aurora"}
                 )

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -1,11 +1,11 @@
 import json
 from os import mkdir
 from os.path import join
-from asterism.file_helpers import remove_file_or_dir, move_file_or_dir, make_tarfile
-from asterism.bagit_helpers import update_bag_info
-
 
 import bag_transfer.lib.log_print as Pter
+from asterism.bagit_helpers import update_bag_info
+from asterism.file_helpers import (make_tarfile, move_file_or_dir,
+                                   remove_file_or_dir)
 from aurora import settings
 from bag_transfer.api.serializers import ArchivesSerializer
 from bag_transfer.lib.bag_checker import bagChecker

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -1,7 +1,7 @@
 import json
 from os import mkdir
 from os.path import join
-from asterism.file_helpers import remove_file_or_dir
+from asterism.file_helpers import remove_file_or_dir, move_file_or_dir, make_tarfile
 
 
 import bag_transfer.lib.log_print as Pter
@@ -77,7 +77,7 @@ class DiscoverTransfers(CronJobBase):
                             BAGLog.log_it("APASS", new_arc)
                             email.setup_message("TRANS_PASS_ALL", new_arc)
                             email.send()
-                            FH.move_file_or_dir(
+                            move_file_or_dir(
                                 "/data/tmp/{}".format(new_arc.bag_it_name),
                                 "{}{}".format(
                                     settings.STORAGE_ROOT_DIR,
@@ -127,7 +127,7 @@ class DeliverTransfers(CronJobBase):
                     {"Origin": "aurora"}
                 )
                 tar_filename = "{}.tar.gz".format(archive.machine_file_identifier)
-                FH.make_tarfile(
+                make_tarfile(
                     join(settings.STORAGE_ROOT_DIR, tar_filename),
                     join(settings.STORAGE_ROOT_DIR, archive.machine_file_identifier),
                 )
@@ -136,7 +136,7 @@ class DeliverTransfers(CronJobBase):
                     join(settings.DELIVERY_QUEUE_DIR, archive.machine_file_identifier)
                 )
 
-                FH.move_file_or_dir(
+                move_file_or_dir(
                     join(settings.STORAGE_ROOT_DIR, tar_filename),
                     join(
                         settings.DELIVERY_QUEUE_DIR,
@@ -158,7 +158,7 @@ class DeliverTransfers(CronJobBase):
                 ) as f:
                     json.dump(archive_json, f, indent=4, sort_keys=True, default=str)
 
-                FH.make_tarfile(
+                make_tarfile(
                     join(
                         settings.DELIVERY_QUEUE_DIR,
                         "{}.tar.gz".format(archive.machine_file_identifier),

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -98,61 +98,6 @@ def tar_has_top_level_only(file_path):
     return top_dir
 
 
-def anon_extract_all(file_path, tmp_dir):
-    """determine which path type, return extraction results"""
-    # is it a dir
-    if os.path.isdir(file_path):
-        return dir_extract_all(file_path, tmp_dir)
-    else:
-        # is it a tar
-        if file_path.endswith("tar.gz") or file_path.endswith(".tar"):
-            return tar_extract_all(file_path, tmp_dir)
-
-        # is it a zip
-        if file_path.endswith(".zip"):
-            return zip_extract_all(file_path, tmp_dir)
-
-    return False
-
-
-def zip_extract_all(file_path, tmp_dir):
-    extracted = False
-    try:
-        zf = zipfile.ZipFile(file_path, "r")
-        zf.extractall(tmp_dir)
-        zf.close()
-        extracted = True
-    except Exception as e:
-        print(e)
-    return extracted
-
-
-def tar_extract_all(file_path, tmp_dir):
-    extracted = False
-    try:
-        tf = tarfile.open(file_path, "r:*")
-        tf.extractall(tmp_dir)
-        tf.close()
-        extracted = True
-    except Exception as e:
-        print(e)
-
-    return extracted
-
-
-def dir_extract_all(file_path, tmp_dir):
-    extracted = False
-    try:
-        # notice forward slash missing
-        if is_dir_or_file("{}{}".format(tmp_dir, file_path.split("/")[-1])):
-            rmtree("{}{}".format(tmp_dir, file_path.split("/")[-1]))
-        copytree(file_path, "{}{}".format(tmp_dir, file_path.split("/")[-1]))
-        extracted = True
-    except Exception as e:
-        print(e)
-    return extracted
-
-
 def get_fields_from_file(file_path):
     fields = {}
     try:

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -189,23 +189,6 @@ def get_fields_from_file(file_path):
 
     return fields
 
-
-def remove_file_or_dir(file_path):
-    if os.path.isfile(file_path):
-        try:
-            os.remove(file_path)
-        except Exception as e:
-            print(e)
-            return False
-    elif os.path.isdir(file_path):
-        try:
-            rmtree(file_path)
-        except Exception as e:
-            print(e)
-            return False
-    return True
-
-
 def move_file_or_dir(src, dest):
     try:
         move(src, dest)

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -147,4 +147,3 @@ def chown_path_to_root(file_path):
     if is_dir_or_file(file_path):
         root_uid = pwd.getpwnam("root").pw_uid
         os.chown(file_path, root_uid, root_uid)
-

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -67,19 +67,6 @@ def files_in_unserialized(dirpath, CK_SUBDIRS=False):
     return files
 
 
-def get_dir_size(start_path):
-    """returns size of contents of dir https://stackoverflow.com/questions/1392413/calculating-a-directory-size-using-python"""
-    total_size = 0
-    for dirpath, dirnames, filenames in os.walk(start_path):
-        for f in filenames:
-            fp = os.path.join(dirpath, f)
-            total_size += os.path.getsize(fp)
-        for d in dirnames:
-            dp = os.path.join(dirpath, d)
-            total_size += os.path.getsize(dp)
-    return total_size if total_size else False
-
-
 def zip_has_top_level_only(file_path):
     items = []
     with zipfile.ZipFile(file_path, "r") as zfile:

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -148,10 +148,3 @@ def chown_path_to_root(file_path):
         root_uid = pwd.getpwnam("root").pw_uid
         os.chown(file_path, root_uid, root_uid)
 
-
-def update_bag_info(bag_path, data):
-    """Adds metadata to `bag-info.txt`"""
-    bag = bagit.Bag(bag_path)
-    for k, v in data.items():
-        bag.info[k] = v
-    bag.save()

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -3,11 +3,9 @@ import pwd
 import re
 import tarfile
 import zipfile
-from shutil import copytree, move, rmtree
-from asterism.file_helpers import is_dir_or_file
 
-import bagit
 import psutil
+from asterism.file_helpers import is_dir_or_file
 
 
 def open_files_list():

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -4,6 +4,7 @@ import re
 import tarfile
 import zipfile
 from shutil import copytree, move, rmtree
+from asterism.file_helpers import is_dir_or_file
 
 import bagit
 import psutil
@@ -121,21 +122,6 @@ def get_fields_from_file(file_path):
 
     return fields
 
-def move_file_or_dir(src, dest):
-    try:
-        move(src, dest)
-    except Exception as e:
-        print(e)
-        return False
-
-
-def is_dir_or_file(file_path):
-    if os.path.isdir(file_path):
-        return True
-    if os.path.isfile(file_path):
-        return True
-    return False
-
 
 def all_paths_exist(list_of_paths):
     for p in list_of_paths:
@@ -161,11 +147,6 @@ def chown_path_to_root(file_path):
     if is_dir_or_file(file_path):
         root_uid = pwd.getpwnam("root").pw_uid
         os.chown(file_path, root_uid, root_uid)
-
-
-def make_tarfile(output_filename, source_dir):
-    with tarfile.open(output_filename, "w:gz") as tar:
-        tar.add(source_dir, arcname=os.path.basename(source_dir))
 
 
 def update_bag_info(bag_path, data):

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -7,10 +7,10 @@ import zipfile
 from pwd import getpwuid
 
 import bag_transfer.lib.log_print as Pter
-from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all
+from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all, is_dir_or_file
 from bag_transfer.lib.files_helper import (all_paths_exist,
                                            files_in_unserialized, 
-                                           is_dir_or_file, open_files_list,
+                                           open_files_list,
                                            tar_has_top_level_only,
                                            zip_has_top_level_only)
 from bag_transfer.lib.virus_scanner import VirusScan

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -5,10 +5,11 @@ import shutil
 import tarfile
 import zipfile
 from pwd import getpwuid
-from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all, is_dir_or_file
-
 
 import bag_transfer.lib.log_print as Pter
+from asterism.file_helpers import (get_dir_size, is_dir_or_file,
+                                   remove_file_or_dir, tar_extract_all,
+                                   zip_extract_all)
 from bag_transfer.lib.files_helper import (all_paths_exist,
                                            files_in_unserialized,
                                            open_files_list,

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -7,13 +7,11 @@ import zipfile
 from pwd import getpwuid
 
 import bag_transfer.lib.log_print as Pter
-from asterism.file_helpers import remove_file_or_dir, get_dir_size
+from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all
 from bag_transfer.lib.files_helper import (all_paths_exist,
                                            files_in_unserialized, 
                                            is_dir_or_file, open_files_list,
-                                           tar_extract_all,
                                            tar_has_top_level_only,
-                                           zip_extract_all,
                                            zip_has_top_level_only)
 from bag_transfer.lib.virus_scanner import VirusScan
 from bag_transfer.models import BAGLog, Organization

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -7,10 +7,11 @@ import zipfile
 from pwd import getpwuid
 
 import bag_transfer.lib.log_print as Pter
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.files_helper import (all_paths_exist,
                                            files_in_unserialized, get_dir_size,
                                            is_dir_or_file, open_files_list,
-                                           remove_file_or_dir, tar_extract_all,
+                                           tar_extract_all,
                                            tar_has_top_level_only,
                                            zip_extract_all,
                                            zip_has_top_level_only)

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -7,9 +7,9 @@ import zipfile
 from pwd import getpwuid
 
 import bag_transfer.lib.log_print as Pter
-from asterism.file_helpers import remove_file_or_dir
+from asterism.file_helpers import remove_file_or_dir, get_dir_size
 from bag_transfer.lib.files_helper import (all_paths_exist,
-                                           files_in_unserialized, get_dir_size,
+                                           files_in_unserialized, 
                                            is_dir_or_file, open_files_list,
                                            tar_extract_all,
                                            tar_has_top_level_only,

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -10,7 +10,7 @@ from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_
 
 import bag_transfer.lib.log_print as Pter
 from bag_transfer.lib.files_helper import (all_paths_exist,
-                                           files_in_unserialized, 
+                                           files_in_unserialized,
                                            open_files_list,
                                            tar_has_top_level_only,
                                            zip_has_top_level_only)

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -5,9 +5,10 @@ import shutil
 import tarfile
 import zipfile
 from pwd import getpwuid
+from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all, is_dir_or_file
+
 
 import bag_transfer.lib.log_print as Pter
-from asterism.file_helpers import remove_file_or_dir, get_dir_size, zip_extract_all, tar_extract_all, is_dir_or_file
 from bag_transfer.lib.files_helper import (all_paths_exist,
                                            files_in_unserialized, 
                                            open_files_list,

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -6,7 +6,6 @@ from os import chown, listdir, path, rename
 from asterism.file_helpers import anon_extract_all
 
 from aurora import settings
-from bag_transfer.lib import files_helper as FH
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
                                  Archives, BagItProfile, BagItProfileBagInfo,

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -3,8 +3,8 @@ import random
 import string
 from datetime import datetime
 from os import chown, listdir, path, rename
-from asterism.file_helpers import anon_extract_all
 
+from asterism.file_helpers import anon_extract_all
 from aurora import settings
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -3,6 +3,7 @@ import random
 import string
 from datetime import datetime
 from os import chown, listdir, path, rename
+from asterism.file_helpers import anon_extract_all
 
 from aurora import settings
 from bag_transfer.lib import files_helper as FH
@@ -206,7 +207,7 @@ def create_target_bags(target_str, test_bags_dir, org, username=None):
     index = 0
 
     for bags in target_bags:
-        FH.anon_extract_all(
+        anon_extract_all(
             path.join(test_bags_dir, bags), org.org_machine_upload_paths()[0]
         )
         # Renames extracted path -- add index suffix to prevent collision

--- a/aurora/bag_transfer/test/test_bags.py
+++ b/aurora/bag_transfer/test/test_bags.py
@@ -1,7 +1,7 @@
 import os
 import random
-from asterism.file_helpers import remove_file_or_dir
 
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.bag_checker import bagChecker
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import Archives, BAGLog, Organization, User

--- a/aurora/bag_transfer/test/test_bags.py
+++ b/aurora/bag_transfer/test/test_bags.py
@@ -2,7 +2,7 @@ import os
 import random
 
 from bag_transfer.lib.bag_checker import bagChecker
-from bag_transfer.lib.files_helper import remove_file_or_dir
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import Archives, BAGLog, Organization, User
 from bag_transfer.test import helpers

--- a/aurora/bag_transfer/test/test_bags.py
+++ b/aurora/bag_transfer/test/test_bags.py
@@ -1,8 +1,8 @@
 import os
 import random
+from asterism.file_helpers import remove_file_or_dir
 
 from bag_transfer.lib.bag_checker import bagChecker
-from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import Archives, BAGLog, Organization, User
 from bag_transfer.test import helpers

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -1,6 +1,6 @@
 import random
-from asterism.file_helpers import remove_file_or_dir
 
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.test import helpers
 from django.test import TransactionTestCase

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -1,6 +1,6 @@
 import random
-
 from asterism.file_helpers import remove_file_or_dir
+
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.test import helpers
 from django.test import TransactionTestCase

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -1,6 +1,6 @@
 import random
 
-from bag_transfer.lib.files_helper import remove_file_or_dir
+from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.test import helpers
 from django.test import TransactionTestCase

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asterism==0.5.2
 attrs==19.3.0
 bagit==1.7.0
 bagit-profile==1.3.1


### PR DESCRIPTION
Remove functions that are in asterism from files_helper, and replace importing those functions from files_helper with asterism.

Fixes #386, fixes partially #382 