### PR TITLE
Use bagit helpers in asterism

### DIFF
--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -5,6 +5,7 @@ from os.path import isfile
 import bagit
 import bagit_profile
 import iso8601
+from asterism.bagit_helpers import get_bag_info_fields
 from asterism.file_helpers import (dir_extract_all, tar_extract_all,
                                    zip_extract_all)
 from bag_transfer.lib import files_helper as FH
@@ -237,6 +238,4 @@ class bagChecker:
         if not self.bag.is_valid():
             return False
 
-        self.bag_info_data = FH.get_fields_from_file(
-            "{}/{}".format(self.archive_path, "bag-info.txt")
-        )
+        self.bag_info_data = get_bag_info_fields("{}".format(self.archive_path))

--- a/aurora/bag_transfer/lib/files_helper.py
+++ b/aurora/bag_transfer/lib/files_helper.py
@@ -1,6 +1,5 @@
 import os
 import pwd
-import re
 import tarfile
 import zipfile
 
@@ -95,30 +94,6 @@ def tar_has_top_level_only(file_path):
         if item.split("/")[0] != top_dir:
             return False
     return top_dir
-
-
-def get_fields_from_file(file_path):
-    fields = {}
-    try:
-        patterns = [r"(?P<key>[\w\-]+)", "(?P<val>.+)"]
-        with open(file_path, "r") as f:
-            for line in f.readlines():
-                line = line.strip("\n")
-
-                row_search = re.search(r":?(\s)?".join(patterns), line)
-                if row_search:
-                    key = row_search.group("key").replace("-", "_").strip()
-                    val = row_search.group("val").strip()
-                    if key in fields:
-                        listval = [fields[key]]
-                        listval.append(val)
-                        fields[key] = listval
-                    else:
-                        fields[key] = val
-    except Exception as e:
-        print(e)
-
-    return fields
 
 
 def all_paths_exist(list_of_paths):


### PR DESCRIPTION
Building on #424, use functions from bagit helpers in asterism. Does not replace anything involving bag validation--that will be part of addressing #393.

Fixes #382