### PR TITLE
Improve Bag-It Profile form for Manifests Allowed

### DIFF
--- a/aurora/bag_transfer/orgs/form.py
+++ b/aurora/bag_transfer/orgs/form.py
@@ -207,6 +207,8 @@ ManifestsAllowedFormset = forms.inlineformset_factory(
     fields=("name",),
     extra=1,
     max_num=2,
+    min_num=1,
+    validate_min=True,
     form=ManifestsAllowedForm,
 )
 

--- a/aurora/bag_transfer/orgs/views.py
+++ b/aurora/bag_transfer/orgs/views.py
@@ -106,24 +106,18 @@ class BagItProfileManageView(TemplateView):
                 }
             )
         bag_info_formset = BagItProfileBagInfoFormset(
-            instance=profile, prefix="bag_info"
-        )
+            instance=profile, prefix="bag_info")
         manifests_allowed_formset = ManifestsAllowedFormset(
-            instance=profile, prefix="manifests_allowed"
-        )
+            instance=profile, prefix="manifests_allowed")
         manifests_formset = ManifestsRequiredFormset(
-            instance=profile, prefix="manifests"
-        )
+            instance=profile, prefix="manifests")
         serialization_formset = AcceptSerializationFormset(
-            instance=profile, prefix="serialization"
-        )
+            instance=profile, prefix="serialization")
         version_formset = AcceptBagItVersionFormset(instance=profile, prefix="version")
         tag_manifests_formset = TagManifestsRequiredFormset(
-            instance=profile, prefix="tag_manifests"
-        )
+            instance=profile, prefix="tag_manifests")
         tag_files_formset = TagFilesRequiredFormset(
-            instance=profile, prefix="tag_files"
-        )
+            instance=profile, prefix="tag_files")
         return render(
             request,
             self.template_name,
@@ -158,41 +152,29 @@ class BagItProfileManageView(TemplateView):
                 serialization=form.cleaned_data["serialization"],
             ).exists():
                 bagit_profile = BagItProfile.objects.filter(
-                    applies_to_organization=form.cleaned_data[
-                        "applies_to_organization"
-                    ],
+                    applies_to_organization=form.cleaned_data["applies_to_organization"],
                     contact_email=form.cleaned_data["contact_email"],
                     source_organization=form.cleaned_data["source_organization"],
                     version=form.cleaned_data["version"],
-                    bagit_profile_identifier=form.cleaned_data[
-                        "bagit_profile_identifier"
-                    ],
+                    bagit_profile_identifier=form.cleaned_data["bagit_profile_identifier"],
                     external_description=form.cleaned_data["external_description"],
-                    serialization=form.cleaned_data["serialization"],
-                )[0]
+                    serialization=form.cleaned_data["serialization"])[0]
             else:
                 bagit_profile = form.save()
             bag_info_formset = BagItProfileBagInfoFormset(
-                request.POST, instance=bagit_profile, prefix="bag_info"
-            )
+                request.POST, instance=bagit_profile, prefix="bag_info")
             manifests_allowed_formset = ManifestsAllowedFormset(
-                request.POST, instance=bagit_profile, prefix="manifests_allowed"
-            )
+                request.POST, instance=bagit_profile, prefix="manifests_allowed")
             manifests_formset = ManifestsRequiredFormset(
-                request.POST, instance=bagit_profile, prefix="manifests"
-            )
+                request.POST, instance=bagit_profile, prefix="manifests")
             serialization_formset = AcceptSerializationFormset(
-                request.POST, instance=bagit_profile, prefix="serialization"
-            )
+                request.POST, instance=bagit_profile, prefix="serialization")
             version_formset = AcceptBagItVersionFormset(
-                request.POST, instance=bagit_profile, prefix="version"
-            )
+                request.POST, instance=bagit_profile, prefix="version")
             tag_manifests_formset = TagManifestsRequiredFormset(
-                request.POST, instance=bagit_profile, prefix="tag_manifests"
-            )
+                request.POST, instance=bagit_profile, prefix="tag_manifests")
             tag_files_formset = TagFilesRequiredFormset(
-                request.POST, instance=bagit_profile, prefix="tag_files"
-            )
+                request.POST, instance=bagit_profile, prefix="tag_files")
             forms_to_save = [
                 bag_info_formset,
                 manifests_allowed_formset,
@@ -204,6 +186,7 @@ class BagItProfileManageView(TemplateView):
             ]
             for formset in forms_to_save:
                 if not formset.is_valid():
+                    print(formset.non_form_errors())
                     messages.error(
                         request,
                         "There was a problem with your submission. Please correct the error(s) below and try again.",
@@ -253,26 +236,19 @@ class BagItProfileManageView(TemplateView):
                 "form": BagItProfileForm(request.POST, instance=instance),
                 "organization": organization,
                 "bag_info_formset": BagItProfileBagInfoFormset(
-                    request.POST, prefix="bag_info"
-                ),
+                    request.POST, prefix="bag_info"),
                 "manifests_allowed_formset": ManifestsAllowedFormset(
-                    request.POST, prefix="manifests_allowed"
-                ),
+                    request.POST, prefix="manifests_allowed"),
                 "manifests_formset": ManifestsRequiredFormset(
-                    request.POST, prefix="manifests"
-                ),
+                    request.POST, prefix="manifests"),
                 "serialization_formset": AcceptSerializationFormset(
-                    request.POST, prefix="serialization"
-                ),
+                    request.POST, prefix="serialization"),
                 "version_formset": AcceptBagItVersionFormset(
-                    request.POST, prefix="version"
-                ),
+                    request.POST, prefix="version"),
                 "tag_manifests_formset": TagManifestsRequiredFormset(
-                    request.POST, prefix="tag_manifests"
-                ),
+                    request.POST, prefix="tag_manifests"),
                 "tag_files_formset": TagFilesRequiredFormset(
-                    request.POST, prefix="tag_files"
-                ),
+                    request.POST, prefix="tag_files"),
                 "meta_page_title": "BagIt Profile",
             },
         )

--- a/aurora/bag_transfer/orgs/views.py
+++ b/aurora/bag_transfer/orgs/views.py
@@ -255,7 +255,7 @@ class BagItProfileManageView(TemplateView):
                 "bag_info_formset": BagItProfileBagInfoFormset(
                     request.POST, prefix="bag_info"
                 ),
-                "manifests__allowed_formset": ManifestsAllowedFormset(
+                "manifests_allowed_formset": ManifestsAllowedFormset(
                     request.POST, prefix="manifests_allowed"
                 ),
                 "manifests_formset": ManifestsRequiredFormset(

--- a/aurora/bag_transfer/templates/bagit_profiles/manage.html
+++ b/aurora/bag_transfer/templates/bagit_profiles/manage.html
@@ -23,13 +23,17 @@
 					</div>
 					</div>
 					<div class="row">
-						<div class="col-md-12">
-							<label id="{{manifests_allowed_formset.prefix}}-label" for="id_{{manifests_allowed_formset.prefix}}-0-name">Manifests Allowed</label>
+						<div class="form-group {% if manifests_allowed_formset.errors %}has-error{% endif %} col-md-12">
+							<label id="{{manifests_allowed_formset.prefix}}-label" for="id_{{manifests_allowed_formset.prefix}}-0-name">Manifests Allowed *</label>
 							{{ manifests_allowed_formset.management_form }}
-							{{ manifests_allowed_formset.non_form_errors }}
 							{% for form in manifests_allowed_formset %}
 								{% include 'bagit_profiles/repeating_form.html' %}
 							{% endfor %}
+							{% if manifests_allowed_formset.non_form_errors %}
+  								{% for error in manifests_allowed_formset.non_form_errors %}
+    								<p class="help-block">{{ error }}</p>
+  								{% endfor %}
+							{% endif %}
 							<p class="help-block">Select allowed algorithm(s) for manifest files. At least one value must be selected for bags to be valid.</p>
 						</div>
 					</div>

--- a/aurora/bag_transfer/templates/bagit_profiles/manage.html
+++ b/aurora/bag_transfer/templates/bagit_profiles/manage.html
@@ -30,7 +30,7 @@
 							{% for form in manifests_allowed_formset %}
 								{% include 'bagit_profiles/repeating_form.html' %}
 							{% endfor %}
-							<p class="help-block">Select allowed algorithm(s) for manifest files. If no value is selected any algorithm is valid.</p>
+							<p class="help-block">Select allowed algorithm(s) for manifest files. At least one value must be selected for bags to be valid.</p>
 						</div>
 					</div>
 					<div class="row">
@@ -41,7 +41,7 @@
 							{% for form in manifests_formset %}
 								{% include 'bagit_profiles/repeating_form.html' %}
 							{% endfor %}
-							<p class="help-block">Select a required algorithm for manifest files. At least one value must be selected in order for bags to be valid.</p>
+							<p class="help-block">Select a required algorithm for manifest files. If no value is selected any algorithm is valid.</p>
 						</div>
 					</div>
 
@@ -53,7 +53,7 @@
 							{% for form in serialization_formset %}
 								{% include 'bagit_profiles/repeating_form.html' %}
 							{% endfor %}
-							<p class="help-block">If serialization of bags is allowed, add all serialization formats accepted. If no values are selected, the bag serialization format will not be checked.</p>
+							<p class="help-block">If serialization is allowed, add all formats accepted. If no values are selected, the serialization format will not be checked.</p>
 						</div>
 					</div>
 

--- a/aurora/bag_transfer/test/test_bagitprofiles.py
+++ b/aurora/bag_transfer/test/test_bagitprofiles.py
@@ -186,10 +186,9 @@ class BagItProfileTestCase(TestCase):
                 "manifests-INITIAL_FORMS": 1,
                 "manifests-0-id": 1,
                 "manifests-0-DELETE": True,
-                "manifests_allowed-TOTAL_FORMS": 0,
-                "manifests_allowed-INITIAL_FORMS": 1,
-                "manifests_allowed-0-id": 1,
-                "manifests_allowed-0-DELETE": True,
+                "manifests_allowed-TOTAL_FORMS": 1,
+                "manifests_allowed-INITIAL_FORMS": 0,
+                "manifests_allowed-0-name": random.choice(["sha256", "sha512"]),
             },
         )
         self.assertEqual(update_request.status_code, 302, "Request was not redirected")


### PR DESCRIPTION
Fixes issue #407 

- Changes the help text for the ManifestsRequired and ManifestsAllowed elements in the BagIt Profile form to reflect recent changes to these after we excluded md5 from the checksum algorithms.
- Shortens some help text in the BagIt Profile form.

Question: I think we should make Manifests Allowed required in the form? I could not figure out how to do that, so tips welcome.