### PR TITLE
Simplify implementation of BagIt Profile validation library

### DIFF
--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -94,7 +94,7 @@ class bagChecker:
                     profile.validate_allow_fetch(self.bag)
                     profile.validate_accept_bagit_version(self.bag)
                 except Exception as e:
-                    self.bag_exception = "Error: {}".format(
+                    self.bag_exception = "Error validating BagIt Profile: {}".format(
                         e.value
                     )
                     return False

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -76,27 +76,8 @@ class bagChecker:
                 )
                 return False
             else:
-
-                # RE IMPLEMENTING  validate() SINCE VALIDATION MESSAGES ARE PRINTED
-                # https://github.com/ruebot/bagit-profiles-validator/blob/master/bagit_profile.py
-                # line 76
-
-                try:
-                    profile.validate_bag_info(self.bag)
-                except Exception as e:
-                    self.bag_exception = "Error in bag-info.txt: {}".format(e.value)
-                    return False
-                try:
-                    profile.validate_payload_manifests_allowed(self.bag)
-                    profile.validate_manifests_required(self.bag)
-                    profile.validate_tag_manifests_required(self.bag)
-                    profile.validate_tag_files_required(self.bag)
-                    profile.validate_allow_fetch(self.bag)
-                    profile.validate_accept_bagit_version(self.bag)
-                except Exception as e:
-                    self.bag_exception = "Error validating BagIt Profile: {}".format(
-                        e.value
-                    )
+                if not profile.validate(self.bag):
+                    self.bag_exception = profile.report.errors
                     return False
                 return True
 

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -88,47 +88,16 @@ class bagChecker:
                     return False
                 try:
                     profile.validate_payload_manifests_allowed(self.bag)
-                except Exception as e:
-                    self.bag_exception = "An unallowed manifest was found: {}".format(
-                        e.value
-                    )
-                    return False
-                try:
                     profile.validate_manifests_required(self.bag)
-                except Exception as e:
-                    self.bag_exception = "Required manifests not found: {}".format(
-                        e.value
-                    )
-                    return False
-                try:
                     profile.validate_tag_manifests_required(self.bag)
-                except Exception as e:
-                    self.bag_exception = "Required tag manifests not found: {}".format(
-                        e.value
-                    )
-                    return False
-                try:
                     profile.validate_tag_files_required(self.bag)
-                except Exception as e:
-                    self.bag_exception = "Required tag files not found: {}".format(
-                        e.value
-                    )
-                    return False
-                try:
                     profile.validate_allow_fetch(self.bag)
-                except Exception as e:
-                    self.bag_exception = "fetch.txt is present but is not allowed: {}".format(
-                        e.value
-                    )
-                    return False
-                try:
                     profile.validate_accept_bagit_version(self.bag)
                 except Exception as e:
-                    self.bag_exception = "Required BagIt version not found: {}".format(
+                    self.bag_exception = "Error: {}".format(
                         e.value
                     )
                     return False
-
                 return True
 
         return False


### PR DESCRIPTION
After reviewing the changes to the ProfileValidationReport class in the BagIt Profile Validation library and the library's implementation in the `_is_rac_bag()` method, I moved all validation methods to one try/except loop, instead of one for each validation. However, I got the same results in by running tests before and after implementing these changes, so I may be missing something.

Addresses #393 