### PR TITLE
Prevent endless authentication loop for logged out users

### DIFF
--- a/aurora/bag_transfer/mixins/authmixins.py
+++ b/aurora/bag_transfer/mixins/authmixins.py
@@ -7,7 +7,7 @@ from django.urls import reverse_lazy
 
 
 class LoggedInMixinDefaults(LoginRequiredMixin):
-    login_url = "/app"
+    login_url = "/login"
 
 
 class ArchivistMixin(LoggedInMixinDefaults, UserPassesTestMixin):

--- a/aurora/bag_transfer/mixins/authmixins.py
+++ b/aurora/bag_transfer/mixins/authmixins.py
@@ -7,7 +7,7 @@ from django.urls import reverse_lazy
 
 
 class LoggedInMixinDefaults(LoginRequiredMixin):
-    login_url = "/login"
+    login_url = reverse_lazy("login")
 
 
 class ArchivistMixin(LoggedInMixinDefaults, UserPassesTestMixin):


### PR DESCRIPTION
Fixes #413 

Changes LoginRequiredMixin `login_url` parameter from `/app` to `/login` to prevent endless redirection when a logged out user tries to get to the site using the `/app` url (like if they have bookmarked the site while logged in).