### PR TITLE
Improve coverage for Accessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,24 +28,19 @@ RUN mkdir /var/run/clamav && \
     sed -i 's/^User .*$/User root/g' /etc/clamav/clamd.conf && \
     sed -i 's/^DatabaseOwner .*$/DatabaseOwner root/g' /etc/clamav/freshclam.conf
 
-# Update clamav databases
-RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-    chown clamav:clamav /var/lib/clamav/*.cvd
-
-
 # Set up SSH
 RUN mkdir /run/sshd && cp -r /etc/ssh /etc/ssh2
 
 # Copy Aurora application files
 RUN mkdir -p /code/
-COPY . /code
+COPY requirements.txt /code
 
 RUN mkdir -p /data/
 
 # Install Python modules
 RUN pip install --upgrade pip && pip install -r /code/requirements.txt
+
+COPY . /code
 
 EXPOSE 8000
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,13 @@ RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
     chmod 750 /var/run/clamav && \
     sed -i 's/^User .*$/User root/g' /etc/clamav/clamd.conf && \
-    sed -i 's/^DatabaseOwner .*$/DatabaseOwner root/g' /etc/clamav/freshclam.conf
+    sed -i 's/^DatabaseOwner .*$/DatabaseOwner root/g' /etc/clamav/freshclam.conf && \
+    freshclam
 
 # Set up SSH
 RUN mkdir /run/sshd && cp -r /etc/ssh /etc/ssh2
 
-# Copy Aurora application files
+# Install Python dependencies
 RUN mkdir -p /code/
 COPY requirements.txt /code
 

--- a/aurora/bag_transfer/test/helpers.py
+++ b/aurora/bag_transfer/test/helpers.py
@@ -185,16 +185,19 @@ def run_transfer_routine():
 def create_rights_statement(record_type=None, org=None, rights_basis=None):
     """Creates a rights statement given a record type, organization and rights basis.
     If any one of these values are not given, random values are assigned."""
+    if len(RecordType.objects.all()) < 1:
+        create_test_record_types()
     record_type = (
         record_type if record_type else random.choice(RecordType.objects.all())
     )
     if org is None:
         org = random.choice(Organization.objects.all())
     if rights_basis is None:
-        rights_basis = random.choices(["Copyright", "Statute", "License", "Other"])
+        rights_basis = random.choice(["Copyright", "Statute", "License", "Other"])
     rights_statement = RightsStatement(organization=org, rights_basis=rights_basis,)
     rights_statement.save()
     rights_statement.applies_to_type.add(record_type)
+    return rights_statement
 
 
 def create_rights_info(rights_statement=None):
@@ -413,9 +416,10 @@ def create_test_bagitprofilebaginfovalues(baginfo=None):
     return values
 
 
-def create_test_baginfometadatas(archive, organization=None, count=1):
+def create_test_baginfometadatas(archive, organization=None, language=None, count=1):
     metadatas = []
     organization = organization if organization else random.choice(Organization.objects.all())
+    language = LanguageCode.objects.get_or_create(code=language)[0] if language else LanguageCode.objects.create(code="mul")
     for x in range(count):
         baginfo = BagInfoMetadata.objects.create(
             archive=archive,
@@ -429,8 +433,9 @@ def create_test_baginfometadatas(archive, organization=None, count=1):
             bagging_date=make_aware(datetime.now()),
             bag_count=1,
             bag_group_identifier=random.randint(1, 5),
-            payload_oxum=random.randint(0, 100),
+            payload_oxum=float(random.randint(0, 100)),
             bagit_profile_identifier="http://www.example.com")
+        baginfo.language.add(language)
         metadatas.append(baginfo)
 
 
@@ -453,6 +458,27 @@ def create_test_languages(count=1):
 
 
 def get_accession_data(creator=None):
+    creator = creator if creator else create_test_record_creators()[0]
+    language = create_test_languages()[0]
+    accession_data = {
+        "use_restrictions": random_string(100),
+        "access_restrictions": random_string(100),
+        "resource": "http://example.org",
+        "description": random_string(150),
+        "end_date": make_aware(random_date(1990)),
+        "extent_size": "17275340",
+        "acquisition_type": random.choice(["donation", "deposit", "gift"]),
+        "title": random_string(255),
+        "accession_number": "2018.184",
+        "start_date": make_aware(random_date(1960)),
+        "extent_files": "14",
+        "appraisal_note": random_string(150),
+        "language": language,
+    }
+    return accession_data
+
+
+def get_accession_form_data(creator=None):
     creator = creator if creator else create_test_record_creators()[0]
     language = create_test_languages()[0]
     accession_data = {

--- a/aurora/bag_transfer/test/setup.py
+++ b/aurora/bag_transfer/test/setup.py
@@ -85,7 +85,7 @@ rights_bases = ["Copyright", "Statute", "License", "Other"]
 basis_data = [
     {
         "rights_basis": "Copyright",
-        "applies_to_type": [1],
+        "applies_to_type": [12],
         "rightsstatementcopyright_set-INITIAL_FORMS": 0,
         "rightsstatementcopyright_set-TOTAL_FORMS": 1,
         "rightsstatementcopyright_set-0-copyright_note": "Test note",
@@ -94,7 +94,7 @@ basis_data = [
     },
     {
         "rights_basis": "Statute",
-        "applies_to_type": [1],
+        "applies_to_type": [12],
         "rightsstatementstatute_set-INITIAL_FORMS": 0,
         "rightsstatementstatute_set-TOTAL_FORMS": 1,
         "rightsstatementstatute_set-0-statute_note": "Test note",
@@ -103,14 +103,14 @@ basis_data = [
     },
     {
         "rights_basis": "License",
-        "applies_to_type": [1],
+        "applies_to_type": [12],
         "rightsstatementlicense_set-INITIAL_FORMS": 0,
         "rightsstatementlicense_set-TOTAL_FORMS": 1,
         "rightsstatementlicense_set-0-license_note": "Test note",
     },
     {
         "rights_basis": "Other",
-        "applies_to_type": [1],
+        "applies_to_type": [12],
         "rightsstatementother_set-INITIAL_FORMS": 0,
         "rightsstatementother_set-TOTAL_FORMS": 1,
         "rightsstatementother_set-0-other_rights_note": "Test note",

--- a/aurora/bag_transfer/test/test_accessioning.py
+++ b/aurora/bag_transfer/test/test_accessioning.py
@@ -1,8 +1,11 @@
+import json
 import random
+from datetime import datetime
 from unittest.mock import patch
 
 from bag_transfer.accession.models import Accession
-from bag_transfer.models import Archives, BAGLog, RecordCreators
+from bag_transfer.accession.views import AccessionCreateView
+from bag_transfer.models import Archives, BAGLog, LanguageCode, RecordCreators
 from bag_transfer.test import helpers
 from django.conf import settings
 from django.test import Client, TestCase
@@ -11,10 +14,13 @@ from django.urls import reverse
 
 class AccessioningTestCase(TestCase):
     def setUp(self):
-        self.client = Client()
         self.orgs = helpers.create_test_orgs(org_count=1)
         self.archives = helpers.create_test_archives(
-            organization=self.orgs[0], process_status=Archives.ACCEPTED)
+            organization=self.orgs[0], process_status=Archives.ACCEPTED, count=5)
+
+    def test_views(self):
+        """Tests views to ensure exceptions are raised appropriately"""
+        self.client = Client()
         groups = helpers.create_test_groups(["accessioning_archivists"])
         helpers.create_test_record_creators(count=3)
         helpers.create_test_user(
@@ -26,34 +32,131 @@ class AccessioningTestCase(TestCase):
         self.client.login(
             username=settings.TEST_USER["USERNAME"],
             password=settings.TEST_USER["PASSWORD"])
-
-    def test_accessioning(self):
-        id_list = ",".join([str(archive.id) for archive in self.archives])
-        self.get_views(id_list)
-        self.post_views(id_list)
+        transfer_ids = [str(a.id) for a in self.archives]
+        self.list_view(",".join(transfer_ids))
+        self.create_view(transfer_ids)
         self.detail_view()
+        self.ajax_list_view(transfer_ids)
+        self.ajax_add_view()
 
-    def get_views(self, id_list):
-        list_response = self.client.get(reverse("accession:list"))
+    def test_grouped_transfer_data(self):
+        """Tests the grouping of transfer data."""
+        # TODO: get_bag_data is not fetching data from the transfers created
+        for archive in self.archives:
+            helpers.create_test_baginfometadatas(archive, organization=archive.organization)
+        notes, dates, descriptions_list, languages_list, extent_files, extent_size, record_type = AccessionCreateView().grouped_transfer_data(self.archives)
+        self.assertEqual(len(notes["appraisal"]), 5)
+        self.assertTrue([isinstance(n, str) for n in notes["appraisal"]])
+        self.assertEqual(len(dates["start"]), 5)
+        self.assertTrue([isinstance(d, datetime) for d in dates["start"]])
+        self.assertEqual(len(dates["end"]), 5)
+        self.assertTrue([isinstance(d, datetime) for d in dates["end"]])
+        self.assertEqual(len(descriptions_list), 5)
+        self.assertTrue([isinstance(d, str) for d in descriptions_list])
+        self.assertEqual(languages_list, ["mul"])
+        self.assertTrue(isinstance(extent_files, int))
+        self.assertTrue(isinstance(extent_size, int))
+        self.assertTrue(isinstance(record_type, str))
+
+    def test_parse_language(self):
+        """Tests the parsing of a single language object from a list."""
+        for list, expected in [([], "und"), (["eng"], "eng"), (["eng", "spa"], "mul")]:
+            language = AccessionCreateView().parse_language(list)
+            self.assertTrue(isinstance(language, LanguageCode))
+            self.assertEqual(language.code, expected)
+
+    def test_parse_title(self):
+        """Tests the construction of a title from transfer data."""
+        for organization, record_type, creators_list, expected in [
+                ("Village Green Preservation Society", "grant records", "Ray Davies", "Village Green Preservation Society, Ray Davies grant records"),
+                ("Village Green Preservation Society", "grant records", "", "Village Green Preservation Society grant records"), ]:
+            title = AccessionCreateView().parse_title(organization, record_type, creators_list)
+            self.assertEqual(title, expected)
+
+    def test_update_accession_rights(self):
+        """Tests that accessions are correctly linked to rights statements."""
+        rights_statements = [helpers.create_rights_statement() for x in range(5)]
+        accession_data = helpers.get_accession_data()
+        accession = Accession.objects.create(**accession_data)
+        AccessionCreateView().update_accession_rights(rights_statements, accession)
+        self.assertTrue([r.accession == accession for r in rights_statements])
+
+    def test_rights_statement_notes(self):
+        rights_basis_list = ["Copyright", "Statute", "License", "Other"]
+        rights_statements = [helpers.create_rights_statement(rights_basis=basis) for basis in rights_basis_list]
+        for statement in rights_statements:
+            helpers.create_rights_info(statement)
+            helpers.create_rights_granted(statement)
+        notes = AccessionCreateView().rights_statement_notes(rights_statements)
+        for basis in rights_basis_list:
+            key = basis.lower()
+            self.assertEqual(len(notes[key]), 2)
+            self.assertTrue(isinstance(n, str) for n in notes[key])
+
+    def assert_status_code(self, method, url, data, status_code):
+        response = getattr(self.client, method)(url, data)
+        self.assertEqual(response.status_code, status_code, "Wrong HTTP status code, expected {}".format(status_code))
+        return response
+
+    @patch("bag_transfer.lib.clients.ArchivesSpaceClient.get_resource")
+    @patch("bag_transfer.lib.clients.ArchivesSpaceClient.authorize")
+    def ajax_add_view(self, mock_authorize, mock_as):
+        mock_as.return_value = {"title": "foo", "id_0": "1", "uri": "foobar"}
+        response = self.client.get(
+            reverse("accession:add"),
+            {"resource_id": 1},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        data = json.loads(response.content)
+        self.assertEqual(data["success"], 1)
+        self.assertEqual(data["title"], "foo (1)")
+        self.assertEqual(data["uri"], "foobar")
+
+        mock_as.side_effect = Exception("mock exception")
+        response = self.client.get(
+            reverse("accession:add"),
+            {"resource_id": 1},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        data = json.loads(response.content)
+        self.assertEqual(data["success"], 0)
+
+    @patch("requests.post")
+    def ajax_list_view(self, transfer_ids, mock_post):
+        """Tests the AJAX logic branch of accession list view."""
+        mock_post.status_code = 200
+        accession = random.choice(Accession.objects.all())
+        list_response = self.client.get(
+            reverse("accession:list"),
+            {"accession_id": accession.pk},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        accession.refresh_from_db()  # refresh to pick up changes
+        self.assertEqual(json.loads(list_response.content)["success"], 1)
+        self.assertEqual(accession.process_status, Accession.DELIVERED)
+
+        accession_id = 10000
+        response = self.client.get(
+            reverse("accession:list"),
+            {"accession_id": accession_id},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest")
         self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(json.loads(response.content)["success"], 0)
 
-        transfer_group = list_response.context["uploads"][0].transfer_group
-        for upload in list_response.context["uploads"]:
+    def list_view(self, id_list):
+        response = self.assert_status_code("get", reverse("accession:list"), None, 200)
+        transfer_group = response.context["uploads"][0].transfer_group
+        for upload in response.context["uploads"]:
             self.assertEqual(upload.transfer_group, transfer_group)
-        self.assertEqual(len(list_response.context["uploads"]), len(self.archives))
+        self.assertEqual(len(response.context["uploads"]), len(self.archives))
 
-        record_response = self.client.get(
-            reverse("accession:add"), {"transfers": id_list})
-        self.assertEqual(record_response.status_code, 200)
+    @patch("requests.post")
+    def create_view(self, id_list, mock_post):
+        """Assert add view handles data and exceptions correctly."""
+        self.assert_status_code("get", reverse("accession:add"), {"transfers": ",".join(id_list)}, 200)
 
-    @patch("bag_transfer.accession.views.requests.post")
-    def post_views(self, id_list, mock_post):
-        mock_post.return_value.status_code.return_value = 200
-        accession_data = helpers.get_accession_data(
+        mock_post.status_code = 200
+        joined_list = ",".join(id_list)
+        accession_data = helpers.get_accession_form_data(
             creator=random.choice(RecordCreators.objects.all()))
-        new_request = self.client.post(
-            "{}?transfers={}".format(reverse("accession:add"), id_list), accession_data)
-        self.assertEqual(new_request.status_code, 302, "Wrong HTTP response code")
+        self.assert_status_code("post", "{}?transfers={}".format(reverse("accession:add"), joined_list), accession_data, 302)
         for acc in Accession.objects.all():
             self.assertTrue(acc.process_status >= Accession.CREATED)
         for arc_id in id_list:
@@ -63,11 +166,17 @@ class AccessioningTestCase(TestCase):
             self.assertEqual(
                 len(BAGLog.objects.filter(archive=archive, code__code_short="BACC")), 1)
 
+        mock_post.side_effect = Exception("mock exception")  # have secondary POST throw exception
+        self.assert_status_code("post", "{}?transfers={}".format(reverse("accession:add"), joined_list), accession_data, 302)
+
+        del accession_data["title"]  # try to submit invalid data
+        self.assert_status_code("post", "{}?transfers={}".format(reverse("accession:add"), joined_list), accession_data, 200)
+
     def detail_view(self):
+        """Assert Accessions detail view returns correct response code."""
         accession = random.choice(Accession.objects.all())
-        accession_response = self.client.get(
-            reverse("accession:detail", kwargs={"pk": accession.pk}))
-        self.assertEqual(accession_response.status_code, 200)
+        self.assert_status_code("get", reverse("accession:detail", kwargs={"pk": accession.pk}), None, 200)
 
     def tearDown(self):
         helpers.delete_test_orgs(self.orgs)
+        Accession.objects.all().delete()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 /code/wait-for-it.sh db:5432 --
 
 # Start clamav services
-/etc/init.d/clamav-daemon start
-/etc/init.d/clamav-freshclam start
+freshclam
+clamd
 
 # Create config.py if it doesn't exist
 if [ ! -f aurora/config.py ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,14 @@
 /code/wait-for-it.sh db:5432 --
 
 # Start clamav services
-freshclam
+echo "Starting ClamAV"
 clamd
+
+# Start SSH
+if [[ -z "${TRAVIS_CI}" ]]; then
+  echo "starting SSH"
+  /usr/sbin/sshd -f /etc/ssh2/sshd_config
+fi
 
 # Create config.py if it doesn't exist
 if [ ! -f aurora/config.py ]; then
@@ -19,12 +25,6 @@ python manage.py migrate
 # Create initial organizations and users
 echo "Setting up organizations and users"
 python manage.py shell < ../setup_objects.py
-
-# Start SSH
-if [[ -z "${TRAVIS_CI}" ]]; then
-  echo "starting sshd"
-  /usr/sbin/sshd -f /etc/ssh2/sshd_config
-fi
 
 #Start server
 echo "Starting server"


### PR DESCRIPTION
Adding additional tests to cover functionality in accession views. This also involved factoring out some smaller units of code from views, which were really complicated and thus difficult to test.
Fixes #456 

Also debugs the setup of ClamAV - fetching definitions via `wget` is no longer supported, so we are now using `freshclam`