### PR TITLE
Improves Organization tests

### DIFF
--- a/aurora/bag_transfer/models.py
+++ b/aurora/bag_transfer/models.py
@@ -54,15 +54,11 @@ class Organization(models.Model):
 
     def org_machine_upload_paths(self):
         """Returns a list containing the organizations' upload and processing paths."""
+        root_dir = "/".join([settings.TRANSFER_UPLOADS_ROOT.rstrip("/"), self.machine_name])
         return [
-            "{}{}/upload/".format(settings.TRANSFER_UPLOADS_ROOT, self.machine_name),
-            "{}{}/processing/".format(
-                settings.TRANSFER_UPLOADS_ROOT, self.machine_name
-            ),
+            "{}/upload/".format(root_dir, self.machine_name),
+            "{}/processing/".format(root_dir, self.machine_name),
         ]
-
-    def org_root_dir(self):
-        return "%s%s".format(settings.TRANSFER_UPLOADS_ROOT, self.machine_name)
 
     def save(self, *args, **kwargs):
         """Adds additional behaviors to the default save function."""

--- a/aurora/bag_transfer/orgs/views.py
+++ b/aurora/bag_transfer/orgs/views.py
@@ -243,6 +243,7 @@ class BagItProfileDetailView(OrgReadViewMixin, DetailView):
 
 
 class BagItProfileAPIAdminView(ManagingArchivistMixin, JSONResponseMixin, TemplateView):
+
     def render_to_response(self, context, **kwargs):
         if not self.request.is_ajax():
             raise Http404

--- a/aurora/bag_transfer/test/test_bagitprofiles.py
+++ b/aurora/bag_transfer/test/test_bagitprofiles.py
@@ -1,200 +1,103 @@
 import random
 
-from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
-                                 BagItProfileBagInfo, ManifestsAllowed,
-                                 ManifestsRequired, TagFilesRequired,
-                                 TagManifestsRequired)
+from bag_transfer.models import BagItProfile, Organization, User
 from bag_transfer.test import helpers
 from bag_transfer.test.setup import BAGINFO_FIELD_CHOICES
-from django.conf import settings
-from django.test import Client, TestCase
+from django.test import TransactionTestCase
 from django.urls import reverse
 
 
-class BagItProfileTestCase(TestCase):
+class BagItProfileTestCase(TransactionTestCase):
+    fixtures = ["complete.json"]
+
     def setUp(self):
-        self.client = Client()
-        self.orgs = helpers.create_test_orgs(org_count=1)
-        self.user = helpers.create_test_user(
-            username=settings.TEST_USER["USERNAME"],
-            password=settings.TEST_USER["PASSWORD"],
-            org=random.choice(self.orgs),
-            groups=helpers.create_test_groups(["managing_archivists"]),
-            is_staff=True)
-        self.client.login(
-            username=self.user.username, password=settings.TEST_USER["PASSWORD"])
-        self.bagitprofiles = []
-        self.baginfos = []
+        self.client.force_login(User.objects.get(username="admin"))
 
-    def test_bagitprofiles(self):
-        for org in self.orgs:
-            profile = helpers.create_test_bagitprofile(organization=org)
-            response = self.client.get(
-                reverse("bagitprofile-detail", kwargs={"pk": profile.pk}))
-            self.assertEqual(response.status_code, 200)
-            self.bagitprofiles.append(profile)
-        self.assertEqual(len(self.bagitprofiles), len(self.orgs))
+    def assert_status_code(self, method, url, data, status_code):
+        response = getattr(self.client, method)(url, data)
+        self.assertEqual(response.status_code, status_code)
 
-        for profile in self.bagitprofiles:
-            helpers.create_test_manifestsallowed(bagitprofile=profile)
-            helpers.create_test_manifestsrequired(bagitprofile=profile)
-            helpers.create_test_acceptserialization(bagitprofile=profile)
-            helpers.create_test_acceptbagitversion(bagitprofile=profile)
-            helpers.create_test_tagmanifestsrequired(bagitprofile=profile)
-            helpers.create_test_tagfilesrequired(bagitprofile=profile)
-            for field in BAGINFO_FIELD_CHOICES:
-                baginfo = helpers.create_test_bagitprofilebaginfo(
-                    bagitprofile=profile, field=field)
-                self.baginfos.append(baginfo)
-            self.assertEqual(
-                len(BagItProfileBagInfo.objects.all()), len(BAGINFO_FIELD_CHOICES))
-
-            for info in self.baginfos:
-                helpers.create_test_bagitprofilebaginfovalues(baginfo=info)
-
-            for obj in (ManifestsAllowed, ManifestsRequired, AcceptSerialization,
-                        AcceptBagItVersion, TagManifestsRequired, TagFilesRequired):
-                self.assertEqual(len(obj.objects.all()), len(self.bagitprofiles))
-
-            for info in BagItProfileBagInfo.objects.all():
-                self.assertTrue(len(info.bagitprofilebaginfovalues_set.all()) > 0)
-
-        # Get bagit profiles for each org
-        for org in self.orgs:
-            self.assertTrue(org.bagit_profile)
-
-        # Test GET views
-        org = random.choice(self.orgs)
-
+    def test_views(self):
+        org = Organization.objects.get(name="Donor Organization")
         for view in ["orgs:bagit-profiles-add", "orgs:bagit-profiles-edit", "organization-bagit-profile"]:
-            response = self.client.get(reverse(view, kwargs={"pk": org.pk}))
-            self.assertEqual(response.status_code, 200, "Response error: {}".format(response))
+            self.assert_status_code("get", reverse(view, kwargs={"pk": org.pk}), None, 200)
+        self.assert_status_code("get", reverse("bagitprofile-list"), None, 200)
+        org.bagit_profile = None
+        org.save()
+        self.assert_status_code("get", reverse("orgs:bagit-profiles-edit", kwargs={"pk": org.pk}), None, 200)
 
-        response = self.client.get(reverse("bagitprofile-list"))
-        self.assertEqual(response.status_code, 200)
-
-        # Creating new BagItProfile
-        organization = random.choice(self.orgs)
-        new_request = self.client.post(
-            reverse("orgs:bagit-profiles-add", kwargs={"pk": organization.pk}),
-            {
-                "contact_email": "archive@rockarch.org",
-                "source_organization": organization.pk,
-                "allow_fetch": random.choice([True, False]),
-                "external_description": helpers.random_string(100),
-                "serialization": random.choice(["forbidden", "required", "optional"]),
-                "version": 0,
-                "bag_info-INITIAL_FORMS": 0,
-                "bag_info-TOTAL_FORMS": 1,
-                "bag_info-0-required": random.choice([True, False]),
-                "bag_info-0-field": random.choice(BAGINFO_FIELD_CHOICES)[0],
-                "bag_info-0-repeatable": random.choice([True, False]),
-                "nested_bag_info-0_bagitprofilebaginfovalues_set-0-name": helpers.random_string(
-                    20
-                ),
-                "nested_bag_info-0_bagitprofilebaginfovalues_set-TOTAL_FORMS": 1,
-                "nested_bag_info-0_bagitprofilebaginfovalues_set-INITIAL_FORMS": 0,
-                "serialization-INITIAL_FORMS": 0,
-                "serialization-TOTAL_FORMS": 1,
-                "serialization-0-name": random.choice(
-                    ["application/zip", "application/x-tar", "application/x-gzip"]
-                ),
-                "tag_files-TOTAL_FORMS": 1,
-                "tag_files-INITIAL_FORMS": 0,
-                "tag_files-0-name": helpers.random_string(20),
-                "tag_manifests-TOTAL_FORMS": 1,
-                "tag_manifests-INITIAL_FORMS": 0,
-                "tag_manifests-0-name": random.choice(["sha256", "sha512"]),
-                "version-TOTAL_FORMS": 1,
-                "version-INITIAL_FORMS": 0,
-                "version-0-name": random.choice(["0.96", 0.97]),
-                "manifests-TOTAL_FORMS": 1,
-                "manifests-INITIAL_FORMS": 0,
-                "manifests-0-name": random.choice(["sha256", "sha512"]),
-                "manifests_allowed-TOTAL_FORMS": 1,
-                "manifests_allowed-INITIAL_FORMS": 0,
-                "manifests_allowed-0-name": random.choice(["sha256", "sha512"]),
-            },
-        )
-        self.assertEqual(new_request.status_code, 302, "Request was not redirected")
-
-        # Updating BagItProfile
-        # update_request = self.client.post(
-        #     reverse(
-        #         "orgs:bagit-profiles-edit",
-        #         kwargs={"pk": organization.pk}),
-        #     {
-        #         "contact_email": "archive@rockarch.org",
-        #         "source_organization": organization.pk,
-        #         "allow_fetch": random.choice([True, False]),
-        #         "external_description": helpers.random_string(100),
-        #         "serialization": "optional",
-        #         "version": 1,
-        #         "bag_info-INITIAL_FORMS": 1,
-        #         "bag_info-TOTAL_FORMS": 1,
-        #         "bag_info-0-id": 6,
-        #         "bag_info-0-required": True,
-        #         "bag_info-0-field": "source_organization",
-        #         "bag_info-0-repeatable": False,
-        #         "nested_bag_info-0_bagitprofilebaginfovalues_set-0-name": "Ford Foundation",
-        #         "nested_bag_info-0_bagitprofilebaginfovalues_set-0-id": 1,
-        #         "nested_bag_info-0_bagitprofilebaginfovalues_set-TOTAL_FORMS": 1,
-        #         "nested_bag_info-0_bagitprofilebaginfovalues_set-INITIAL_FORMS": 1,
-        #         "serialization-INITIAL_FORMS": 1,
-        #         "serialization-TOTAL_FORMS": 3,
-        #         "serialization-0-id": 1,
-        #         "serialization-0-name": "application/zip",
-        #         "serialization-1-name": "application/x-tar",
-        #         "serialization-2-name": "application/x-gzip",
-        #         "tag_files-TOTAL_FORMS": 1,
-        #         "tag_files-INITIAL_FORMS": 1,
-        #         "tag_files-0-id": 1,
-        #         "tag_files-0-DELETE": True,
-        #         "tag_manifests-TOTAL_FORMS": 1,
-        #         "tag_manifests-INITIAL_FORMS": 1,
-        #         "tag_manifests-0-id": 1,
-        #         "tag_manifests-0-DELETE": True,
-        #         "version-TOTAL_FORMS": 2,
-        #         "version-INITIAL_FORMS": 1,
-        #         "version-0-id": 1,
-        #         "version-0-name": "0.96",
-        #         "version-1-name": 0.97,
-        #         "manifests-TOTAL_FORMS": 0,
-        #         "manifests-INITIAL_FORMS": 1,
-        #         "manifests-0-id": 1,
-        #         "manifests-0-DELETE": True,
-        #         "manifests_allowed-TOTAL_FORMS": 1,
-        #         "manifests_allowed-INITIAL_FORMS": 0,
-        #         "manifests_allowed-0-name": random.choice(["sha256", "sha512"]),
-        #     },
-        # )
-        # self.assertEqual(update_request.status_code, 302, "Request was not redirected")
-
-        # Delete bagit profile
-        delete_request = self.client.get(
-            reverse(
-                "orgs:bagit-profiles-api",
-                kwargs={
-                    "pk": organization.pk,
-                    "action": "delete",
-                },
+        data = {
+            "contact_email": "archive@rockarch.org",
+            "source_organization": org.pk,
+            "applies_to_organization": org.pk,
+            "allow_fetch": random.choice([True, False]),
+            "external_description": helpers.random_string(100),
+            "serialization": random.choice(["forbidden", "required", "optional"]),
+            "version": 0,
+            "bag_info-INITIAL_FORMS": 0,
+            "bag_info-TOTAL_FORMS": 1,
+            "bag_info-0-required": random.choice([True, False]),
+            "bag_info-0-field": random.choice(BAGINFO_FIELD_CHOICES)[0],
+            "bag_info-0-repeatable": random.choice([True, False]),
+            "nested_bag_info-0_bagitprofilebaginfovalues_set-0-name": helpers.random_string(20),
+            "nested_bag_info-0_bagitprofilebaginfovalues_set-TOTAL_FORMS": 1,
+            "nested_bag_info-0_bagitprofilebaginfovalues_set-INITIAL_FORMS": 0,
+            "serialization-INITIAL_FORMS": 0,
+            "serialization-TOTAL_FORMS": 1,
+            "serialization-0-name": random.choice(
+                ["application/zip", "application/x-tar", "application/x-gzip"]
             ),
-            {},
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-        )
-        self.assertEqual(delete_request.status_code, 200)
-        resp = delete_request.json()
-        self.assertEqual(resp["success"], 1)
-        non_ajax_request = self.client.get(
-            reverse(
-                "orgs:bagit-profiles-api",
-                kwargs={
-                    "pk": organization.pk,
-                    "action": "delete",
-                },
-            )
-        )
-        self.assertEqual(non_ajax_request.status_code, 404)
+            "tag_files-TOTAL_FORMS": 1,
+            "tag_files-INITIAL_FORMS": 0,
+            "tag_files-0-name": helpers.random_string(20),
+            "tag_manifests-TOTAL_FORMS": 1,
+            "tag_manifests-INITIAL_FORMS": 0,
+            "tag_manifests-0-name": random.choice(["sha256", "sha512"]),
+            "version-TOTAL_FORMS": 1,
+            "version-INITIAL_FORMS": 0,
+            "version-0-name": random.choice(["0.96", 0.97]),
+            "manifests-TOTAL_FORMS": 1,
+            "manifests-INITIAL_FORMS": 0,
+            "manifests-0-name": random.choice(["sha256", "sha512"]),
+            "manifests_allowed-TOTAL_FORMS": 1,
+            "manifests_allowed-INITIAL_FORMS": 0,
+            "manifests_allowed-0-name": random.choice(["sha256", "sha512"]),
+        }
+        self.assert_status_code(
+            "post", reverse("orgs:bagit-profiles-add", kwargs={"pk": org.pk}),
+            data, 302)
+        org.refresh_from_db()
+        self.assertIsNot(None, org.bagit_profile, "BagIt profile was not assigned to organization")
 
-    def tearDown(self):
-        helpers.delete_test_orgs(self.orgs)
+        external_description = helpers.random_string(150)
+        data["external_description"] = external_description
+        self.assert_status_code(
+            "post", reverse("orgs:bagit-profiles-add", kwargs={"pk": org.pk}),
+            data, 302)
+        self.assertIsNot(None, org.bagit_profile, "BagIt profile not assigned to organization")
+        org.refresh_from_db()
+        self.assertEqual(org.bagit_profile.external_description, external_description, "External Description was not updated")
+
+        delete_request = self.client.get(
+            reverse("orgs:bagit-profiles-api", kwargs={"pk": org.pk, "action": "delete"}),
+            {}, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        self.assertEqual(delete_request.status_code, 200)
+        self.assertEqual(delete_request.json()["success"], 1)
+        org.refresh_from_db()
+        self.assertEqual(None, org.bagit_profile, "BagIt Profile not deleted")
+
+        self.assert_status_code(
+            "get", reverse("orgs:bagit-profiles-api", kwargs={"pk": org.pk, "action": "delete"}),
+            None, 404)
+
+        profile = random.choice(BagItProfile.objects.all())
+        self.assert_status_code("get", reverse("orgs:bagit-profiles-detail", kwargs={"pk": profile.pk}), None, 200)
+
+    def test_save_to_org(self):
+        """Asserts that the `save_to_org` method works as intended"""
+        org = random.choice(Organization.objects.all())
+        org.bagit_profile = None
+        org.save()
+        profile = random.choice(BagItProfile.objects.all())
+        profile.save_to_org(org)
+        self.assertIsNot(None, org.bagit_profile)

--- a/aurora/bag_transfer/test/test_orgs.py
+++ b/aurora/bag_transfer/test/test_orgs.py
@@ -1,0 +1,69 @@
+import random
+from unittest.mock import patch
+
+from bag_transfer.models import Organization, User
+from bag_transfer.test import helpers
+from django.test import TransactionTestCase
+from django.urls import reverse
+
+
+class OrgTestCase(TransactionTestCase):
+    fixtures = ["complete.json"]
+
+    def setUp(self):
+        self.client.force_login(User.objects.get(username="admin"))
+
+    def assert_status_code(self, method, url, data, status_code):
+        response = getattr(self.client, method)(url, data)
+        self.assertEqual(response.status_code, status_code)
+        return response
+
+    @patch("bag_transfer.lib.RAC_CMD.add_org")
+    def test_org_views(self, mock_add_org):
+        list = self.assert_status_code("get", reverse("orgs:list"), None, 200)
+        self.assertEqual(len(list.context["object_list"]), len(Organization.objects.all()))
+        for view in ["orgs:detail", "orgs:edit"]:
+            self.assert_status_code(
+                "get", reverse(view, kwargs={"pk": Organization.objects.get(name="Donor Organization").pk}),
+                None, 200)
+
+        org_data = {
+            "active": True,
+            "name": "Test Organization",
+            "acquisition_type": "donation"
+        }
+        self.assert_status_code("get", reverse("orgs:add"), None, 200)
+        self.assert_status_code("post", reverse("orgs:add"), org_data, 302)
+        org_data["active"] = False
+        self.assert_status_code("post", reverse("orgs:add"), org_data, 200)
+        mock_add_org.assert_called_once()
+
+    def test_org_model_methods(self):
+        self.org_machine_upload_paths()
+        self.save_test()
+        self.users_by_org()
+        self.is_org_active()
+
+    def org_machine_upload_paths(self):
+        machine_name = helpers.random_string(20)
+        org = Organization(machine_name=machine_name)
+        upload_paths = org.org_machine_upload_paths()
+        self.assertEqual(len(upload_paths), 2)
+        self.assertTrue(any([u.endswith("{}/upload/".format(machine_name)) for u in upload_paths]))
+        self.assertTrue(any([u.endswith("{}/processing/".format(machine_name)) for u in upload_paths]))
+
+    def save_test(self):
+        org = random.choice(Organization.objects.all())
+        org.is_active = False
+        org.save()
+        self.assertTrue([u.is_active is False for u in org.org_users()])
+
+    def users_by_org(self):
+        users_by_org = Organization.users_by_org()
+        self.assertTrue(isinstance(users_by_org, list))
+        self.assertEqual(len(Organization.objects.all()), len(users_by_org))
+
+    def is_org_active(self):
+        org = random.choice(Organization.objects.filter(is_active=True))
+        self.assertEqual(Organization.is_org_active(org.machine_name), org)
+        self.assertEqual(Organization.is_org_active("foobar"), None)

--- a/aurora/bag_transfer/test/test_users.py
+++ b/aurora/bag_transfer/test/test_users.py
@@ -12,7 +12,6 @@ org_count = 1
 class UserTestCase(TestCase):
     def setUp(self):
         self.orgs = helpers.create_test_orgs(org_count=org_count)
-        self.client.force_login(User.objects.get(username="admin"))
 
     def assert_status_code(self, method, url, data, status_code):
         response = getattr(self.client, method)(url, data)


### PR DESCRIPTION
Improves test coverage for Organizations, including BagIt profiles. Separates out User and Organization tests for more easily maintainable tests.

Fixes #459 