### PR TITLE
Add test coverage for `lib` files

### DIFF
--- a/aurora/bag_transfer/api/views.py
+++ b/aurora/bag_transfer/api/views.py
@@ -91,7 +91,7 @@ class ArchivesViewSet(
     def update(self, request, pk=None, *args, **kwargs):
         try:
             identifier = request.data.get("identifier")
-            CleanupRoutine(identifier).run()
+            CleanupRoutine().run(identifier)
             return super(ArchivesViewSet, self).update(request, *args, **kwargs)
         except Exception as e:
             return Response({"detail": str(e)}, status=500)

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from iso639 import languages
 
 
-class bagChecker:
+class BagChecker:
     def __init__(self, archiveObj):
 
         self.tmp_path = settings.TRANSFER_EXTRACT_TMP

--- a/aurora/bag_transfer/lib/bag_checker.py
+++ b/aurora/bag_transfer/lib/bag_checker.py
@@ -1,6 +1,6 @@
 import glob
 import json
-from os.path import isfile
+from os.path import isfile, join
 
 import bagit
 import bagit_profile
@@ -21,7 +21,7 @@ class BagChecker:
         self.bag_dates_to_validate = ["Date_Start", "Date_End", "Bagging_Date"]
         self.archiveObj = archiveObj
         self.archive_extracted = self._extract_archive()
-        self.archive_path = "{}{}".format(self.tmp_path, self.archiveObj.bag_it_name)
+        self.archive_path = join(self.tmp_path, self.archiveObj.bag_it_name)
         self.ecode = ""
         self.bag = {}
         self.bag_info_data = {}
@@ -42,6 +42,7 @@ class BagChecker:
         return True
 
     def _is_generic_bag(self):
+        """Basic BagIt validation."""
         try:
             self.bag = bagit.Bag(self.archive_path)
             self.bag.validate()
@@ -52,7 +53,7 @@ class BagChecker:
             self.bag_exception = "Error during BagIt validation: {}".format(e)
             return False
         else:
-            for filename in glob.glob("{}/manifest-*.txt".format(self.archive_path)):
+            for filename in glob.glob(join(self.archive_path, "manifest-*.txt")):
                 with open(filename, "r") as manifest_file:
                     self.archiveObj.manifest = manifest_file.read()
             self._retrieve_bag_info_key_val()  # run now to prevent multiple calls below
@@ -65,15 +66,11 @@ class BagChecker:
             self.bag_exception = "No BagIt Profile to validate against"
             return False
         else:
-
             try:
-                profile = bagit_profile.Profile(
-                    self.bag_info_data["BagIt_Profile_Identifier"]
-                )
+                profile = bagit_profile.Profile(self.bag_info_data["BagIt_Profile_Identifier"])
             except BaseException:
                 self.bag_exception = "Cannot retrieve BagIt Profile from URL {}".format(
-                    self.bag_info_data["BagIt_Profile_Identifier"]
-                )
+                    self.bag_info_data["BagIt_Profile_Identifier"])
                 return False
             else:
                 if not profile.validate(self.bag):
@@ -113,7 +110,7 @@ class BagChecker:
     def _has_valid_metadata_file(self):
         """checks if the metadata file path and is json is correct if exist"""
 
-        metadata_file = "/".join([str(self.bag), "data", "metadata.json"])
+        metadata_file = join(str(self.bag), "data", "metadata.json")
 
         if not isfile(metadata_file):
             return True
@@ -133,7 +130,6 @@ class BagChecker:
             return self.bag_failed()
 
         if not self.bag_info_data:
-            # log internal error here
             return self.bag_failed()
 
         BAGLog.log_it("PBAG", self.archiveObj)
@@ -177,4 +173,4 @@ class BagChecker:
         if not self.bag.is_valid():
             return False
 
-        self.bag_info_data = get_bag_info_fields("{}".format(self.archive_path))
+        self.bag_info_data = get_bag_info_fields(self.archive_path)

--- a/aurora/bag_transfer/lib/cleanup.py
+++ b/aurora/bag_transfer/lib/cleanup.py
@@ -4,21 +4,10 @@ from os.path import isfile, join
 from aurora import settings
 
 
-class CleanupError(Exception):
-    pass
-
-
 class CleanupRoutine:
-    def __init__(self, identifier):
-        self.identifier = identifier
-        self.dir = settings.DELIVERY_QUEUE_DIR
-
-    def run(self):
-        try:
-            self.filepath = "{}.tar.gz".format(join(self.dir, self.identifier))
-            if isfile(self.filepath):
-                remove(self.filepath)
-                return "Transfer {} removed.".format(self.identifier)
-            return "Transfer {} was not found.".format(self.identifier)
-        except Exception as e:
-            raise CleanupError(e)
+    def run(self, identifier):
+        filepath = "{}.tar.gz".format(join(settings.DELIVERY_QUEUE_DIR, identifier))
+        if isfile(filepath):
+            remove(filepath)
+            return "Transfer {} removed.".format(identifier)
+        return "Transfer {} was not found.".format(identifier)

--- a/aurora/bag_transfer/lib/clients.py
+++ b/aurora/bag_transfer/lib/clients.py
@@ -1,6 +1,4 @@
-import json
-
-from requests import Session
+from asnake.client import ASnakeClient
 
 
 class ArchivesSpaceClientError(Exception):
@@ -9,42 +7,16 @@ class ArchivesSpaceClientError(Exception):
 
 class ArchivesSpaceClient:
     def __init__(self, baseurl, username, password, repo_id):
+        self.client = ASnakeClient(
+            baseurl=baseurl,
+            username=username,
+            password=password)
         self.repo_id = repo_id
-        self.baseurl = baseurl
-        self.session = Session()
-        self.session.headers.update({"Accept": "application/json"})
-        try:
-            self.authorize(username, password)
-        except Exception as e:
-            raise ArchivesSpaceClientError(
-                "Couldn't authenticate user credentials for ArchivesSpace: {}".format(e)
-            )
 
-    def get_resource(self, resource_id, *args, **kwargs):
-        resp = self.session.get(
-            "/".join(
-                [
-                    self.baseurl.rstrip("/"),
-                    "/repositories/{repo_id}/resources/{resource_id}",
-                ]
-            ).format(repo_id=self.repo_id, resource_id=resource_id)
-        )
-        if resp.status_code == 200:
-            return resp.json()
+    def get_resource(self, resource_id):
+        """Returns a JSON representation of a resource, or raises an exception if an error occurs."""
+        resource = self.client.get("/repositories/{}/resources/{}".format(self.repo_id, resource_id))
+        if resource.status_code == 200:
+            return resource.json()
         else:
-            raise ArchivesSpaceClientError(resp.json()["error"])
-
-    def authorize(self, username, password):
-        resp = self.session.post(
-            "/".join([self.baseurl.rstrip("/"), "users/{username}/login"]).format(
-                username=username
-            ),
-            params={"password": password, "expiring": False},
-        )
-
-        if resp.status_code != 200:
-            raise ArchivesSpaceClientError((resp.status_code))
-        else:
-            session_token = json.loads(resp.text)["session"]
-            self.session.headers["X-ArchivesSpace-Session"] = session_token
-            return session_token
+            raise ArchivesSpaceClientError(resource.json()["error"])

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -52,9 +52,7 @@ class DiscoverTransfers(CronJobBase):
                         process_status=Archives.TRANSFER_COMPLETED)
 
                     BAGLog.log_it("ASAVE", new_arc)
-                    print(
-                        "\nValidating transfer {}".format(new_arc.machine_file_identifier)
-                    )
+                    print("\nValidating transfer {}".format(new_arc.machine_file_identifier))
 
                     if upload_list["auto_fail"]:
                         new_arc.add_autofail_information(upload_list)
@@ -67,11 +65,7 @@ class DiscoverTransfers(CronJobBase):
                     else:
                         bag = BagChecker(new_arc)
                         if bag.bag_passed_all():
-                            print(
-                                "Transfer {} is valid".format(
-                                    new_arc.machine_file_identifier
-                                )
-                            )
+                            print("Transfer {} is valid".format(new_arc.machine_file_identifier))
                             new_arc.process_status = Archives.VALIDATED
                             new_arc.bag_it_valid = True
                             BAGLog.log_it("APASS", new_arc)
@@ -89,11 +83,7 @@ class DiscoverTransfers(CronJobBase):
                                 settings.STORAGE_ROOT_DIR, new_arc.machine_file_identifier
                             )
                         else:
-                            print(
-                                "Transfer {} is invalid".format(
-                                    new_arc.machine_file_identifier
-                                )
-                            )
+                            print("Transfer {} is invalid".format(new_arc.machine_file_identifier))
                             new_arc.process_status = Archives.INVALID
                             BAGLog.log_it(bag.ecode, new_arc)
                             email.setup_message("TRANS_FAIL_VAL", new_arc)

--- a/aurora/bag_transfer/lib/cron.py
+++ b/aurora/bag_transfer/lib/cron.py
@@ -8,7 +8,7 @@ from asterism.file_helpers import (make_tarfile, move_file_or_dir,
                                    remove_file_or_dir)
 from aurora import settings
 from bag_transfer.api.serializers import ArchivesSerializer
-from bag_transfer.lib.bag_checker import bagChecker
+from bag_transfer.lib.bag_checker import BagChecker
 from bag_transfer.lib.mailer import Mailer
 from bag_transfer.lib.transfer_routine import TransferRoutine
 from bag_transfer.models import Archives, BAGLog, Organization, User
@@ -65,7 +65,7 @@ class DiscoverTransfers(CronJobBase):
                         remove_file_or_dir(new_arc.machine_file_path)
 
                     else:
-                        bag = bagChecker(new_arc)
+                        bag = BagChecker(new_arc)
                         if bag.bag_passed_all():
                             print(
                                 "Transfer {} is valid".format(

--- a/aurora/bag_transfer/lib/transfer_routine.py
+++ b/aurora/bag_transfer/lib/transfer_routine.py
@@ -176,7 +176,7 @@ class TransferRoutine(object):
             # get directory
             for d in obj["dirs"]:
                 # check files in directory are on list
-                for fls in files_in_unserialized(d, True):
+                for fls in files_in_unserialized(d):
                     if fls in open_files:
                         rm_list.append((org, 1, d))
             return rm_list

--- a/aurora/bag_transfer/models.py
+++ b/aurora/bag_transfer/models.py
@@ -364,7 +364,7 @@ class Archives(models.Model):
         try:
             bag_data = BagInfoMetadata(
                 archive=self,
-                source_organization=Organization.objects.get(name=metadata["Source_Organization"]),
+                source_organization=self.organization,
                 external_identifier=metadata.get("External_Identifier", ""),
                 internal_sender_description=metadata.get("Internal_Sender_Description", ""),
                 title=metadata.get("Title", ""),

--- a/aurora/bag_transfer/test/test_accessioning.py
+++ b/aurora/bag_transfer/test/test_accessioning.py
@@ -85,8 +85,7 @@ class AccessioningTestCase(TransactionTestCase):
         return response
 
     @patch("bag_transfer.lib.clients.ArchivesSpaceClient.get_resource")
-    @patch("bag_transfer.lib.clients.ArchivesSpaceClient.authorize")
-    def ajax_add_view(self, mock_authorize, mock_as):
+    def ajax_add_view(self, mock_as):
         mock_as.return_value = {"title": "foo", "id_0": "1", "uri": "foobar"}
         response = self.client.get(
             reverse("accession:add"),

--- a/aurora/bag_transfer/test/test_cleanup.py
+++ b/aurora/bag_transfer/test/test_cleanup.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from aurora import settings
+from bag_transfer.lib.cleanup import CleanupRoutine
+from django.test import TestCase
+
+
+class CleanupRoutineTestCase(TestCase):
+
+    def setUp(self):
+        if not Path(settings.DELIVERY_QUEUE_DIR).exists():
+            Path(settings.DELIVERY_QUEUE_DIR).mkdir()
+
+    def test_cleanup(self):
+        """Asserts that the CleanupRoutine finds and deletes a file given an identifier"""
+        identifier = "foo"
+        Path(settings.DELIVERY_QUEUE_DIR, "{}.tar.gz".format(identifier)).touch()
+        self.assertTrue(CleanupRoutine().run(identifier), "Transfer {} was found".format(identifier))
+        self.assertTrue(CleanupRoutine().run(identifier), "Transfer {} was not found".format(identifier))

--- a/aurora/bag_transfer/test/test_clients.py
+++ b/aurora/bag_transfer/test/test_clients.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+from bag_transfer.lib.clients import (ArchivesSpaceClient,
+                                      ArchivesSpaceClientError)
+from django.test import TestCase
+
+
+class ClientTestCase(TestCase):
+
+    @patch("requests.Session.get")
+    @patch("requests.Session.post")
+    def test_get_resources(self, mock_post, mock_get):
+        """Ensure client handles requests and errors."""
+        return_value = {}
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.text = '{"session": "12345"}'
+        client = ArchivesSpaceClient("baseurl", "username", "password", "repo_id")
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = return_value
+        self.assertEqual(client.get_resource("1"), return_value)
+        mock_get.return_value.status_code = 404
+        mock_get.return_value.json.return_value = {"error": "foobar"}
+        with self.assertRaisesMessage(ArchivesSpaceClientError, "foobar"):
+            client.get_resource("1")

--- a/aurora/bag_transfer/test/test_cron.py
+++ b/aurora/bag_transfer/test/test_cron.py
@@ -1,11 +1,13 @@
 import os
 import random
+import shutil
 from unittest.mock import patch
 
 import bagit
 from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.cron import DeliverTransfers, DiscoverTransfers
-from bag_transfer.models import Archives, Organization, User
+from bag_transfer.models import (Archives, DashboardMonthData, Organization,
+                                 User)
 from bag_transfer.test import helpers
 from bag_transfer.test.setup import BAGS_REF
 from django.conf import settings
@@ -16,10 +18,20 @@ class CronTestCase(TestCase):
     fixtures = ["complete.json"]
 
     def setUp(self):
+        """
+        Delete existing Archive and DashboardMonthData objects and remove any
+        stray objects from the organization upload directory.
+        """
         Archives.objects.all().delete()
+        DashboardMonthData.objects.all().delete()
+        self.org = random.choice(Organization.objects.all())
         for d in [settings.DELIVERY_QUEUE_DIR, settings.STORAGE_ROOT_DIR]:
             if os.path.isdir(d):
                 remove_file_or_dir(d)
+        for d in self.org.org_machine_upload_paths():
+            if os.path.exists(d):
+                shutil.rmtree(d)
+                os.makedirs(d)
 
     def test_cron(self):
         self.discover_bags()
@@ -28,11 +40,10 @@ class CronTestCase(TestCase):
     @patch("bag_transfer.lib.bag_checker.BagChecker.bag_passed_all")
     def discover_bags(self, mock_passed_all):
         bag_name, _ = BAGS_REF[0]
-        org = random.choice(Organization.objects.all())
         for bag_passed_all in [True, False]:
             self.bags = helpers.create_target_bags(
                 bag_name, settings.TEST_BAGS_DIR,
-                org, username=random.choice(User.objects.filter(organization=org)).username)
+                self.org, username=random.choice(User.objects.filter(organization=self.org)).username)
             mock_passed_all.return_value = bag_passed_all
             discovered = DiscoverTransfers().do()
             self.assertIsNot(False, discovered)

--- a/aurora/bag_transfer/test/test_cron.py
+++ b/aurora/bag_transfer/test/test_cron.py
@@ -5,23 +5,18 @@ from unittest.mock import patch
 import bagit
 from asterism.file_helpers import remove_file_or_dir
 from bag_transfer.lib.cron import DeliverTransfers, DiscoverTransfers
-from bag_transfer.models import Archives
+from bag_transfer.models import Archives, Organization, User
 from bag_transfer.test import helpers
 from bag_transfer.test.setup import BAGS_REF
 from django.conf import settings
-from django.test import Client, TestCase
+from django.test import TestCase
 
 
 class CronTestCase(TestCase):
+    fixtures = ["complete.json"]
+
     def setUp(self):
-        self.orgs = helpers.create_test_orgs(org_count=1)
-        self.user = helpers.create_test_user(
-            username=settings.TEST_USER['USERNAME'],
-            password=settings.TEST_USER['PASSWORD'],
-            org=random.choice(self.orgs),
-            groups=helpers.create_test_groups(['managing_archivists']),
-            is_staff=True)
-        self.client = Client()
+        Archives.objects.all().delete()
         for d in [settings.DELIVERY_QUEUE_DIR, settings.STORAGE_ROOT_DIR]:
             if os.path.isdir(d):
                 remove_file_or_dir(d)
@@ -31,12 +26,16 @@ class CronTestCase(TestCase):
         self.deliver_bags()
 
     @patch("bag_transfer.lib.bag_checker.BagChecker.bag_passed_all")
-    def discover_bags(self, mock_bag_check):
+    def discover_bags(self, mock_passed_all):
         bag_name, _ = BAGS_REF[0]
-        helpers.create_target_bags(bag_name, settings.TEST_BAGS_DIR, self.orgs[0], username=self.user.username)
-        mock_bag_check.return_value = True
-        discovered = DiscoverTransfers().do()
-        self.assertIsNot(False, discovered)
+        org = random.choice(Organization.objects.all())
+        for bag_passed_all in [True, False]:
+            self.bags = helpers.create_target_bags(
+                bag_name, settings.TEST_BAGS_DIR,
+                org, username=random.choice(User.objects.filter(organization=org)).username)
+            mock_passed_all.return_value = bag_passed_all
+            discovered = DiscoverTransfers().do()
+            self.assertIsNot(False, discovered)
 
     def deliver_bags(self):
         for archive in Archives.objects.filter(process_status=Archives.VALIDATED):
@@ -54,4 +53,6 @@ class CronTestCase(TestCase):
             self.assertEqual(bag.info["Origin"], "aurora")
 
     def tearDown(self):
-        helpers.delete_test_orgs(self.orgs)
+        for d in [settings.DELIVERY_QUEUE_DIR, settings.STORAGE_ROOT_DIR]:
+            if os.path.isdir(d):
+                remove_file_or_dir(d)

--- a/aurora/bag_transfer/test/test_cron.py
+++ b/aurora/bag_transfer/test/test_cron.py
@@ -30,7 +30,7 @@ class CronTestCase(TestCase):
         self.discover_bags()
         self.deliver_bags()
 
-    @patch("bag_transfer.lib.bag_checker.bagChecker.bag_passed_all")
+    @patch("bag_transfer.lib.bag_checker.BagChecker.bag_passed_all")
     def discover_bags(self, mock_bag_check):
         bag_name, _ = BAGS_REF[0]
         helpers.create_target_bags(bag_name, settings.TEST_BAGS_DIR, self.orgs[0], username=self.user.username)

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -25,7 +25,7 @@ class TransferRoutineTestCase(TestCase):
 
     # def test_run_routine(self):
     #
-    #     test_on_bagchecker = [r[0] for r in setup.BAGS_REF if len(r) > 2 and r[2]]
+    #     test_on_BagChecker = [r[0] for r in setup.BAGS_REF if len(r) > 2 and r[2]]
     #     test_on_transfer_routine = [r[0] for r in setup.BAGS_REF if len(r) > 3 and r[3]]
     #
     #     for ref in setup.BAGS_REF:
@@ -62,14 +62,14 @@ class TransferRoutineTestCase(TestCase):
     #             if trans["auto_fail"]:
     #                 continue
     #
-    #             bag = bagChecker(archive)
+    #             bag = BagChecker(archive)
     #             passed_all_results = bag.bag_passed_all()
     #
     #             if ref[0] in ["valid_bag", "no_metadata_file"]:
     #                 self.assertTrue(passed_all_results, "Bag unexpectedly invalid")
     #             else:
     #                 self.assertFalse(passed_all_results, "Bag unexpectedly valid")
-    #                 if ref[0] in test_on_bagchecker:
+    #                 if ref[0] in test_on_BagChecker:
     #                     self.assertEqual(ref[1], bag.ecode)
     #
     #             # deleting path in processing and tmp dir

--- a/aurora/bag_transfer/test/test_transfer_routine.py
+++ b/aurora/bag_transfer/test/test_transfer_routine.py
@@ -4,9 +4,11 @@ import shutil
 
 from asterism.file_helpers import remove_file_or_dir
 from aurora import settings
+from bag_transfer.lib.bag_checker import BagChecker
 from bag_transfer.lib.transfer_routine import TransferRoutine
-from bag_transfer.models import Archives, DashboardMonthData, Organization
-from bag_transfer.test import helpers
+from bag_transfer.models import (Archives, DashboardMonthData, Organization,
+                                 User)
+from bag_transfer.test import helpers, setup
 from django.test import TestCase
 
 
@@ -19,65 +21,67 @@ class TransferRoutineTestCase(TestCase):
         self.reset_org_dirs(Organization.objects.all())
 
     def test_setup_routine(self):
+        """Asserts TransferRoutine sets up correctly."""
         self.routine = TransferRoutine()
         self.sub_test_db_has_active_orgs()
         self.sub_test_verify_organizations_paths()
         self.sub_test_no_orgs_with_dirs()
         self.sub_test_contents_dictionary()
 
-    # def test_run_routine(self):
-    #
-    #     test_on_BagChecker = [r[0] for r in setup.BAGS_REF if len(r) > 2 and r[2]]
-    #     test_on_transfer_routine = [r[0] for r in setup.BAGS_REF if len(r) > 3 and r[3]]
-    #
-    #     for ref in setup.BAGS_REF:
-    #
-    #         helpers.create_target_bags(ref[0], settings.TEST_BAGS_DIR, self.orgs[0])
-    #         tr = TransferRoutine()
-    #         self.assertTrue(tr.setup_routine(), "Transfer routine did not set up properly")
-    #         self.assertTrue(isinstance(tr.run_routine(), dict), "Expected transfer routine to produce a dict, got {} instead".format(tr.run_routine()))
-    #
-    #         for trans in tr.transfers:
-    #             if not trans["file_name"].startswith(ref[0]):
-    #                 continue
-    #             if ref[0] == "valid_bag":
-    #                 self.assertFalse(trans["auto_fail"])
-    #             else:
-    #                 if ref[0] in test_on_transfer_routine:
-    #                     self.assertTrue(trans["auto_fail"])
-    #                     self.assertEqual(ref[1], trans["auto_fail_code"])
-    #
-    #             archive = Archives.initial_save(
-    #                 self.orgs[0],
-    #                 None,
-    #                 trans["file_path"],
-    #                 trans["file_size"],
-    #                 trans["file_modtime"],
-    #                 Archives().gen_identifier(),
-    #                 trans["file_type"],
-    #                 trans["bag_it_name"])
-    #             archive.organization.name = "Ford Foundation"
-    #             archive.organization.save()
-    #
-    #             self.assertIsNot(False, archive.machine_file_identifier, "Expected bag identifier to exist")
-    #
-    #             if trans["auto_fail"]:
-    #                 continue
-    #
-    #             bag = BagChecker(archive)
-    #             passed_all_results = bag.bag_passed_all()
-    #
-    #             if ref[0] in ["valid_bag", "no_metadata_file"]:
-    #                 self.assertTrue(passed_all_results, "Bag unexpectedly invalid")
-    #             else:
-    #                 self.assertFalse(passed_all_results, "Bag unexpectedly valid")
-    #                 if ref[0] in test_on_BagChecker:
-    #                     self.assertEqual(ref[1], bag.ecode)
-    #
-    #             # deleting path in processing and tmp dir
-    #             remove_file_or_dir(
-    #                 os.path.join(settings.TRANSFER_EXTRACT_TMP, archive.bag_it_name))
-    #             remove_file_or_dir(archive.machine_file_path)
+    def test_run_routine(self):
+        """Asserts TransferRoutine handles valid and invalid bags."""
+        test_on_BagChecker = [r[0] for r in setup.BAGS_REF if len(r) > 2 and r[2]]
+        test_on_transfer_routine = [r[0] for r in setup.BAGS_REF if len(r) > 3 and r[3]]
+        org = random.choice(Organization.objects.all())
+        user = random.choice(User.objects.filter(organization=org))
+
+        for prefix, error, *rest in setup.BAGS_REF:
+
+            helpers.create_target_bags(
+                prefix, settings.TEST_BAGS_DIR, org, user.username)
+            tr = TransferRoutine()
+            routine = tr.run_routine()
+            self.assertTrue(
+                isinstance(routine, list),
+                "Expected transfer routine to produce a list, got {} instead".format(routine))
+
+            for trans in tr.transfers:
+                if not trans["file_name"].startswith(prefix):
+                    continue
+                if prefix == "valid_bag":
+                    self.assertFalse(trans["auto_fail"])
+                else:
+                    if prefix in test_on_transfer_routine:
+                        self.assertTrue(trans["auto_fail"])
+                        self.assertEqual(error, trans["auto_fail_code"])
+
+                archive = Archives.objects.create(
+                    organization=org,
+                    user_uploaded=user,
+                    machine_file_path=trans["file_path"],
+                    machine_file_size=trans["file_size"],
+                    machine_file_upload_time=trans["file_modtime"],
+                    machine_file_identifier=Archives().gen_identifier(),
+                    machine_file_type=trans["file_type"],
+                    bag_it_name=trans["bag_it_name"])
+
+                if trans["auto_fail"]:
+                    continue
+
+                bag = BagChecker(archive)
+                passed_all_results = bag.bag_passed_all()
+
+                if prefix in ["valid_bag", "no_metadata_file"]:
+                    self.assertTrue(passed_all_results, "Bag unexpectedly invalid")
+                else:
+                    self.assertFalse(passed_all_results, "Bag unexpectedly valid")
+                    if prefix in test_on_BagChecker:
+                        self.assertEqual(error, bag.ecode)
+
+                # deleting path in processing and tmp dir
+                remove_file_or_dir(
+                    os.path.join(settings.TRANSFER_EXTRACT_TMP, archive.bag_it_name))
+                remove_file_or_dir(archive.machine_file_path)
 
     def sub_test_db_has_active_orgs(self):
         """Asserts TransferRoutine setup handles inactive organizations."""
@@ -102,7 +106,7 @@ class TransferRoutineTestCase(TestCase):
         self.assertEqual(
             original_active_count - 1, len(self.routine.active_organizations),
             "Expected one organization to have been removed from TransferRoutine.active_organizations")
-        self.reset_org_dirs(last_org)
+        self.reset_org_dirs([last_org])
 
     def sub_test_no_orgs_with_dirs(self):
         self.change_all_orgs_in_list_status(Organization.objects.all(), True)
@@ -117,10 +121,18 @@ class TransferRoutineTestCase(TestCase):
 
     def sub_test_contents_dictionary(self):
         """Asserts the TransferRoutine contents dictionary is correctly set up."""
-        self.assertFalse(self.routine.setup_routine(), "Expected TransferRoutine setup to fail because there are no transfers in the transfer directory")
+        self.assertFalse(
+            self.routine.setup_routine(),
+            "Expected TransferRoutine setup to fail because there are no transfers in the transfer directory")
+        self.assertFalse(
+            self.routine.has_setup_err,
+            "Expected TransferRoutine.has_setup_err to be False because there are no transfers in the transfer directory")
         organization = random.choice(Organization.objects.filter(is_active=True))
         helpers.create_target_bags("valid_bag", settings.TEST_BAGS_DIR, organization)
         self.assertTrue(self.routine.setup_routine(), "Expected TransferRoutine setup to succeed.")
+        self.assertTrue(
+            isinstance(self.routine.routine_contents_dictionary, dict),
+            "Expecting TransferRoutine.routine_contents_dictionary to be a dict")
         self.reset_org_dirs(Organization.objects.all())
 
     def change_all_orgs_in_list_status(self, orgs={}, Status=False):

--- a/aurora/bag_transfer/test/test_users.py
+++ b/aurora/bag_transfer/test/test_users.py
@@ -95,7 +95,7 @@ class UserTestCase(TestCase):
         """Ensures correct HTTP status codes are received for views."""
         for view in ["users:detail", "users:edit"]:
             self.assert_status_code(
-                "get", reverse(view, kwargs={"pk": random.choice(User.objects.filter(archives__isnull=False)).pk}), None, 200)
+                "get", reverse(view, kwargs={"pk": random.choice(User.objects.filter(transfers__isnull=False)).pk}), None, 200)
         for view in ["users:add", "users:list", "users:password-change"]:
             self.assert_status_code("get", reverse(view), None, 200)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+ArchivesSnake==0.9.1
 asterism==0.5.2
 attrs==19.3.0
 bagit==1.7.0


### PR DESCRIPTION
Add test coverage for files in the `lib` directory. Significantly, this includes the `BagChecker` and `TransferRoutine` classes. Also implements ArchivesSnake instead of our custom client.

Fixes #463 
Fixes #465 