### PR TITLE
Use `granted_note` instead of `note` in RightsStatementRightsGranted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     clamav-freshclam \
     default-libmysqlclient-dev \
     python-dev \
-    python-pip \
+    python3-pip \
     ssh \
     vim \
     wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-buster
 
 ENV PYTHONUNBUFFERED 1
 

--- a/aurora/bag_transfer/api/serializers.py
+++ b/aurora/bag_transfer/api/serializers.py
@@ -26,7 +26,7 @@ class RecordCreatorsSerializer(serializers.ModelSerializer):
 
 
 class RightsStatementRightsGrantedSerializer(serializers.ModelSerializer):
-    note = serializers.StringRelatedField(source="rights_granted_note")
+    granted_note = serializers.StringRelatedField(source="rights_granted_note")
     end_date = serializers.SerializerMethodField()
     grant_restriction = serializers.CharField(source="restriction")
 

--- a/aurora/bag_transfer/api/serializers.py
+++ b/aurora/bag_transfer/api/serializers.py
@@ -26,7 +26,7 @@ class RecordCreatorsSerializer(serializers.ModelSerializer):
 
 
 class RightsStatementRightsGrantedSerializer(serializers.ModelSerializer):
-    granted_note = serializers.StringRelatedField(source="rights_granted_note")
+    granted_note = serializers.StringRelatedField(source="rights_granted_note", allow_null=True)
     end_date = serializers.SerializerMethodField()
     grant_restriction = serializers.CharField(source="restriction")
 

--- a/aurora/bag_transfer/api/serializers.py
+++ b/aurora/bag_transfer/api/serializers.py
@@ -38,7 +38,7 @@ class RightsStatementRightsGrantedSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = RightsStatementRightsGranted
-        fields = ("act", "start_date", "end_date", "note", "grant_restriction")
+        fields = ("act", "start_date", "end_date", "granted_note", "grant_restriction")
 
 
 class RightsStatementSerializer(serializers.ModelSerializer):

--- a/aurora/bag_transfer/fixtures/complete.json
+++ b/aurora/bag_transfer/fixtures/complete.json
@@ -5768,7 +5768,7 @@
         "start_date_period": null,
         "end_date_period": 5,
         "end_date_open": true,
-        "rights_granted_note": null,
+        "rights_granted_note": "",
         "restriction": "allow"
     }
 },

--- a/aurora/bag_transfer/fixtures/complete.json
+++ b/aurora/bag_transfer/fixtures/complete.json
@@ -5753,7 +5753,7 @@
         "start_date_period": 5,
         "end_date_period": null,
         "end_date_open": true,
-        "rights_granted_note": "",
+        "rights_granted_note": null,
         "restriction": "disallow"
     }
 },
@@ -5768,7 +5768,7 @@
         "start_date_period": null,
         "end_date_period": 5,
         "end_date_open": true,
-        "rights_granted_note": "",
+        "rights_granted_note": null,
         "restriction": "allow"
     }
 },

--- a/aurora/bag_transfer/test/test_api.py
+++ b/aurora/bag_transfer/test/test_api.py
@@ -74,6 +74,7 @@ class APITest(TestMixin, TestCase):
         for org in Organization.objects.all():
             rights_statements = self.client.get(reverse("organization-rights-statements", kwargs={"pk": org.pk}))
             for statement in rights_statements.json():
+                print(statement)
                 self.assertTrue(is_valid(statement, "rights_statement.json"))
         for queryset, view, schema in [
                 (Transfer.objects.filter(process_status__gte=Transfer.ACCESSIONING_STARTED), "transfer-detail", "aurora_bag"),

--- a/aurora/bag_transfer/test/test_api.py
+++ b/aurora/bag_transfer/test/test_api.py
@@ -74,7 +74,6 @@ class APITest(TestMixin, TestCase):
         for org in Organization.objects.all():
             rights_statements = self.client.get(reverse("organization-rights-statements", kwargs={"pk": org.pk}))
             for statement in rights_statements.json():
-                print(statement)
                 self.assertTrue(is_valid(statement, "rights_statement.json"))
         for queryset, view, schema in [
                 (Transfer.objects.filter(process_status__gte=Transfer.ACCESSIONING_STARTED), "transfer-detail", "aurora_bag"),

--- a/requirements.in
+++ b/requirements.in
@@ -17,6 +17,6 @@ psutil==5.8.0
 pyClamd==0.4.0
 python-dateutil==2.8.2
 PyYAML==5.4.1
-rac_schemas==0.28
+rac_schemas==0.29
 requests==2.26.0
 uritemplate==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   archivessnake
     #   health-check
-rac_schemas==0.28
+rac_schemas==0.29
     # via -r requirements.in
 rapidfuzz==1.4.1
     # via archivessnake


### PR DESCRIPTION
Update RightsStatementRightsGranted serializer to produce `granted_note` keys instead of `note`. Because the underlying model field has not been changed, this should not affect any other methods.

Fixes #497 