### PR TITLE
Don't overwrite basis dates

### DIFF
--- a/aurora/bag_transfer/models.py
+++ b/aurora/bag_transfer/models.py
@@ -39,7 +39,7 @@ class Organization(models.Model):
         return reverse("orgs:edit", kwargs={"pk": self.pk})
 
     def rights_statements(self):
-        return self.rightsstatement_set.filter(transfer__isnull=True)
+        return self.rightsstatement_set.filter(transfer__isnull=True, accession__isnull=True)
 
     def org_users(self):
         return User.objects.filter(organization=self).order_by("username")

--- a/aurora/bag_transfer/models.py
+++ b/aurora/bag_transfer/models.py
@@ -390,9 +390,12 @@ class Transfer(models.Model):
         """Assigns rights to an Archive."""
 
         def update_date(obj, date_key, period_key, bag_date):
-            if not getattr(obj, date_key):
-                period = getattr(obj, period_key) if getattr(obj, period_key) else 0
-                setattr(obj, date_key, bag_date + relativedelta.relativedelta(years=period))
+            """Updates the date if it does not exist or is not open."""
+            open_key = period_key.replace("_period", "_open")
+            if not(getattr(obj, date_key)):
+                if hasattr(obj, open_key) and not getattr(obj, open_key):
+                    period = getattr(obj, period_key) if getattr(obj, period_key) else 0
+                    setattr(obj, date_key, bag_date + relativedelta.relativedelta(years=period))
 
         try:
             bag_data = self.bag_data

--- a/aurora/bag_transfer/test/test_archives.py
+++ b/aurora/bag_transfer/test/test_archives.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 
-class BagTestCase(TestMixin, TestCase):
+class ArchivesTestCase(TestMixin, TestCase):
     fixtures = ["complete.json"]
 
     def assert_all_views(self, organization=None):

--- a/aurora/bag_transfer/test/test_rights.py
+++ b/aurora/bag_transfer/test/test_rights.py
@@ -50,7 +50,6 @@ class RightsTestCase(TestMixin, TestCase):
         for merge_list in [
                 random.choices(RightsStatement.objects.filter(rights_basis="Copyright"), k=3),
                 random.choices(RightsStatement.objects.all(), k=3)]:
-            merge_list = random.choices(RightsStatement.objects.filter(rights_basis="Copyright"), k=3)
             merged = RightsStatement.merge_rights(merge_list)
             self.assertTrue(isinstance(merged, list))
             self.assertTrue([isinstance(m, RightsStatement) for m in merged])


### PR DESCRIPTION
Adds extra clause to `assign_rights` to not overwrite end dates. Also filters out rights statements attached to accessions from organization rights statements.

Fixes #508
Fixes #509