### PR TITLE
Use 4-byte character set and collation

### DIFF
--- a/aurora/settings.py
+++ b/aurora/settings.py
@@ -98,6 +98,7 @@ DATABASES = {
         "PASSWORD": config.SQL_PASSWORD,
         "HOST": config.SQL_HOST,
         "PORT": config.SQL_PORT,
+        "OPTIONS": {"charset": "utf8mb4"}
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       MYSQL_ROOT_PASSWORD: example
     volumes:
       - auroradb:/var/lib/mysql
+    command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
   web:
     build: .
     entrypoint: /code/entrypoint.sh


### PR DESCRIPTION
Fixes #563 

On deployed sites, this will require updating the existing database's character set and collation.