### PR TITLE
Remove source directories after validation and tarball

### DIFF
--- a/bag_transfer/lib/cron.py
+++ b/bag_transfer/lib/cron.py
@@ -86,7 +86,8 @@ class DiscoverTransfers(CronJobBase):
                         tar_filename = "{}.tar.gz".format(new_transfer.machine_file_identifier)
                         make_tarfile(
                             new_transfer.machine_file_path,
-                            join(settings.TRANSFER_EXTRACT_TMP, tar_filename))
+                            join(settings.TRANSFER_EXTRACT_TMP, tar_filename),
+                            remove_src=True)
                         if settings.S3_USE:
                             s3_client = boto3.client(
                                 's3',


### PR DESCRIPTION
Removes source directories after they have been tarballed by passing the `remove_src` flag. Fixes #647 