### PR TITLE
Add template tag for form prefixes

### DIFF
--- a/bag_transfer/templates/bagit_profiles/manage.html
+++ b/bag_transfer/templates/bagit_profiles/manage.html
@@ -1,4 +1,5 @@
 {% extends 'transfers/base.html' %}
+{% load util %}
 
 {% block h1_title %}{{page_title}} <small>{{organization}}</small> <span class="badge">Version {{form.version.value}}</span>{% endblock %}
 
@@ -101,7 +102,7 @@
 					{{ bag_info_formset.management_form }}
 					{{ bag_info_formset.non_form_errors }}
 					{% for form in bag_info_formset %}
-					<div id="{{ form.prefix }}-row" class="{{form.prefix|slice:'-2'}} well dynamic-form">
+					<div id="{{ form.prefix }}-row" class="{{ form.prefix | trim_form_prefix }} well dynamic-form">
 						{% for hidden in form.hidden_fields %}
 					    {{ hidden }}
 						{% endfor %}
@@ -114,7 +115,7 @@
 								<div class="nested-form">
 									{{ form.nested.management_form }}
 									{{ form.nested.non_form_errors }}
-									<a id="remove-{{ form.prefix }}-row" href="javascript:void(0)" class="delete-row btn btn-sm btn-danger pull-right" data-target="{{form.prefix|slice:'-2'}}"><i class="fa fa-times"></i> Delete Field</a>
+									<a id="remove-{{ form.prefix }}-row" href="javascript:void(0)" class="delete-row btn btn-sm btn-danger pull-right" data-target="{{ form.prefix | trim_form_prefix }}"><i class="fa fa-times"></i> Delete Field</a>
 									<label id="values-label">Values</label>
 									<div class="show-values-inputs">
 										<a href="javascript:void(0)" class="btn btn-primary btn-sm add-values">Add Controlled Values</a>
@@ -161,6 +162,7 @@
 	}
 	function renumberForms(prefix) {
 		forms = $('[class^='+prefix+']')
+		console.log(prefix)
 		for (var i=0, formCount=forms.length; i<formCount; i++) {
 			updateElementIndex(forms.get(i), prefix, i)
 			$(forms.get(i)).find('[name^='+prefix+']').each(function() {

--- a/bag_transfer/templates/bagit_profiles/repeating_form.html
+++ b/bag_transfer/templates/bagit_profiles/repeating_form.html
@@ -1,4 +1,6 @@
-<div id="{{ form.prefix }}-row" class="{{form.prefix|slice:'-2'}} dynamic-form">
+{% load util %}
+
+<div id="{{ form.prefix }}-row" class="{{form.prefix| trim_form_prefix}} dynamic-form">
   <div class="row">
     <div class="col-xs-6">
       {% for field in form %}
@@ -6,8 +8,8 @@
       {% endfor %}
     </div>
     <div class="col-xs-4">
-      <a href="javascript:void(0)" class="delete-row btn btn-sm btn-danger" data-target="{{form.prefix|slice:'-2'}}"><i class="fa fa-times"></i> Delete</a>
-      <a {% if not forloop.last %}style="display:none;"{% endif %} href="javascript:void(0)" class="add-row btn btn-sm btn-primary" data-target="{{form.prefix|slice:'-2'}}"><i class="fa fa-plus"></i> Add</a>
+      <a href="javascript:void(0)" class="delete-row btn btn-sm btn-danger" data-target="{{form.prefix | trim_form_prefix }}"><i class="fa fa-times"></i> Delete</a>
+      <a {% if not forloop.last %}style="display:none;"{% endif %} href="javascript:void(0)" class="add-row btn btn-sm btn-primary" data-target="{{form.prefix| trim_form_prefix }}"><i class="fa fa-plus"></i> Add</a>
     </div>
   </div>
 </div>

--- a/bag_transfer/templatetags/util.py
+++ b/bag_transfer/templatetags/util.py
@@ -26,3 +26,9 @@ def progress_class(status):
 @register.filter
 def progress_percentage(status):
     return int(round(float(status) / Transfer.ACCESSIONING_COMPLETE * 100))
+
+
+@register.filter
+def trim_form_prefix(value):
+    split_prefix = value.split("-")
+    return "-".join(split_prefix[:2])


### PR DESCRIPTION
Introduces a template tag to handle form prefixes rather than a static string slicing method (which started to cause errors when values went from one place to two). Fixes #659 