### PR TITLE
Disable sorting for specific saved accession table columns

### DIFF
--- a/bag_transfer/templates/accession/saved.html
+++ b/bag_transfer/templates/accession/saved.html
@@ -30,6 +30,9 @@
       createdRow: function(row, data, dataIndex) {
           $(row).attr('data-accession-id', data[5]);
       },
+      columnDefs: [
+        { orderable: false, targets: [3, 4] } // Disable sorting for transfers and status
+      ],
       order: [1, 'desc'],
       processing: true,
       serverSide: true,


### PR DESCRIPTION
Saved Accessions transfers and status columns aren't appropriate for sorting given data types in columns. Remove this functionality to avoid user confusion.