### PR TITLE
Remove sorting from users table columns

### DIFF
--- a/bag_transfer/templates/users/list.html
+++ b/bag_transfer/templates/users/list.html
@@ -54,6 +54,8 @@
 
 {% block extra_js %}
 <script type="text/javascript">
-  new DataTable('#user-table')
+  new DataTable('#user-table', {
+    ordering: false
+  });
 </script>
 {% endblock %}


### PR DESCRIPTION
The Aurora redesign has implemented search and pagination for this "Users" table, but sorting adds levels of complication with the "last login" data that is not a complication worth addressing at this time. Search should be sufficient to filter table results as needed.