### PR TITLE
Correctly set initial values

### DIFF
--- a/bag_transfer/bagit_profiles/form.py
+++ b/bag_transfer/bagit_profiles/form.py
@@ -1,7 +1,8 @@
 from django import forms
 
-from bag_transfer.models import (BagItProfile, BagItProfileBagInfo,
-                                 BagItProfileBagInfoValues)
+from bag_transfer.models import (AcceptBagItVersion, AcceptSerialization,
+                                 BagItProfile, BagItProfileBagInfo,
+                                 BagItProfileBagInfoValues, ManifestsAllowed)
 
 
 class BagItProfileForm(forms.ModelForm):
@@ -56,8 +57,9 @@ class BagItProfileForm(forms.ModelForm):
         self.legends = self.Meta.legends  # Make legends accessible
         self.help_texts = self.Meta.help_texts  # Make help_texts accessible
         self.fields["external_description"].initial = "BagIt Profile for transferring records to the Rockefeller Archive Center."
-        self.fields["manifests_allowed"].initial = [1, 2]
-        self.fields["accept_serialization"].initial = [1, 2, 3]
+        self.fields["manifests_allowed"].initial = [obj.pk for obj in ManifestsAllowed.objects.all()]
+        self.fields["accept_serialization"].initial = [obj.pk for obj in AcceptSerialization.objects.all()]
+        self.fields["accept_bagit_version"].initial = [obj.pk for obj in AcceptBagItVersion.objects.filter(name='1.0')]
 
 
 class BagItProfileBagInfoForm(forms.ModelForm):


### PR DESCRIPTION
The initial values for the CheckboxMultipleFields in the BagItProfile Form come from associated object primary keys, not the order of the choices in the form. These initial values work in a local environment because the primary keys of the objects happen to match their order in the form, but in dev and prod they are different.

I've implemented logic to fetch these values dynamically from data in the database.

Fixes #721 