### PR TITLE
Handle dismiss of AS resource ID

### DIFF
--- a/bag_transfer/templates/accession/create.html
+++ b/bag_transfer/templates/accession/create.html
@@ -118,12 +118,11 @@
 
           // Display the resource title and success alert
           $('#resource_title').contents().first().replaceWith(resp.title); //only replace the title text, but keep  the dismiss button
-          $('#id_resource').val(resp.uri) // store URI in hidden field
           $('#resource_result').show()
           displayMessage('blue', resp.title + ' was added as the target ArchiveSpace resource');
 
         } else {
-          $('#resource_input').fadeTo(0, 1).show()
+          $('#resource_input_wrapper').fadeTo(0, 1).show()
           displayMessage('orange', 'There was an error finding this resource in ArchivesSpace: '+ resp.error, false);
         }
       })
@@ -133,7 +132,9 @@
     $('#resource_title_dismiss').on('click', function(){
       $('#resource_result').hide()
       $('#resource_title').text("")
-      $('#id_resource').val("")
+      $('#resource_id').val("")
+      $('#resource_input').fadeTo(0, 1);
+      $('#resource_input_wrapper').fadeTo(0, 1).show()
     });
 
     // Form validation before submit

--- a/bag_transfer/templates/accession/create.html
+++ b/bag_transfer/templates/accession/create.html
@@ -118,6 +118,7 @@
 
           // Display the resource title and success alert
           $('#resource_title').contents().first().replaceWith(resp.title); //only replace the title text, but keep  the dismiss button
+          $('#id_resource').val(resp.uri) // store URI in hidden field
           $('#resource_result').show()
           displayMessage('blue', resp.title + ' was added as the target ArchiveSpace resource');
 
@@ -132,6 +133,7 @@
     $('#resource_title_dismiss').on('click', function(){
       $('#resource_result').hide()
       $('#resource_title').text("")
+      $('#id_resource').val("")
       $('#resource_id').val("")
       $('#resource_input').fadeTo(0, 1);
       $('#resource_input_wrapper').fadeTo(0, 1).show()


### PR DESCRIPTION
Better JS handling for dismiss of ArchivesSpace resource ID. 

Fixes #731 