### PR TITLE
Add missing closing tag in footer link

### DIFF
--- a/bag_transfer/templates/transfers/footer.html
+++ b/bag_transfer/templates/transfers/footer.html
@@ -176,6 +176,7 @@
               href="https://aptrust.github.io/dart-docs/"
             >
             DART Documentation
+            </a>
           </li>
           <li class="footer-secondary__list-item">
             <a


### PR DESCRIPTION
Fixes typo of missing closing tag in footer link.